### PR TITLE
試合管理＞時刻マスタの機能追加・UI変更

### DIFF
--- a/client/src/components/TimerMasterComponent.tsx
+++ b/client/src/components/TimerMasterComponent.tsx
@@ -1,20 +1,16 @@
 import { FC } from 'react';
-import { Paper, Typography, Grid, Button, ButtonGroup, Tooltip, Box } from '@mui/material';
+import { Paper, Typography, Grid, Button, ButtonGroup } from '@mui/material';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import FastRewindIcon from '@mui/icons-material/FastRewind';
 import FastForwardIcon from '@mui/icons-material/FastForward';
-import Forward10Icon from '@mui/icons-material/Forward10';
-import Replay10Icon from '@mui/icons-material/Replay10';
-import AddIcon from '@mui/icons-material/Add';
-import RemoveIcon from '@mui/icons-material/Remove';
 import { TimerDisplay } from './TimerDisplay';
 import { TimeProgressConfigType } from '@/config/types';
 import styled from '@emotion/styled';
 import { CurrentPhaseState } from '@/slices/phase';
-import { Label } from '@mui/icons-material';
+import { ConditionalTooltip } from '@/ui/ConditionalTooltip';
 
 const DetailInfoUl = styled('ul')({
   paddingInlineStart: '22px',
@@ -68,95 +64,74 @@ export const TimerMasterComponent: FC<TimerMasterComponentProps> = ({
               displayTimeVariant="h2"
             />
           </Grid>
-          <Grid item xs={12} sx={{ 
+          <Grid item xs={12} sx={{
             display: 'flex',
             justifyContent: 'center',
-           }}>
-            <ButtonGroup size="small" sx={{ 
+          }}>
+            <ButtonGroup size="small" variant="contained" color="inherit" sx={{
               opacity: .2,
               transition: '0.3s',
               '&:hover': {
                 opacity: '0.75',
               },
-             }}>
-              <Tooltip title="最初のフェーズに">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onFirstPhase} disabled={isFirstPhase}>
-                    <SkipPreviousIcon />
-                  </Button>
-                </span>
-              </Tooltip>
-              <Tooltip title="前のフェーズに">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onPrevPhase} disabled={isFirstPhase}>
-                    <FastRewindIcon />
-                  </Button>
-                </span>
-              </Tooltip>
-              <Tooltip title={isPaused ? "再開" : "一時停止"}>
-                <span>
-                  <Button variant="contained" color="grey" onClick={onPauseButton} disabled={phaseConfig.type !== "count"}>
-                    {
-                      isPaused ? <PlayArrowIcon /> : <PauseIcon />
-                    }
-                  </Button>
-                </span>
-              </Tooltip>
-              <Tooltip title="次のフェーズに">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onNextPhase} disabled={isLastPhase}>
-                    <FastForwardIcon />
-                  </Button>
-                </span>
-              </Tooltip>
-              <Tooltip title="最初のフェーズに">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onLastPhase} disabled={isLastPhase}>
-                    <SkipNextIcon />
-                  </Button>
-                </span>
-              </Tooltip>
+            }}>
+              <ConditionalTooltip condition={!isFirstPhase} title="最初のフェーズに">
+                <Button onClick={onFirstPhase} disabled={isFirstPhase}>
+                  <SkipPreviousIcon />
+                </Button>
+              </ConditionalTooltip>
+              <ConditionalTooltip condition={!isFirstPhase} title="前のフェーズに">
+                <Button onClick={onPrevPhase} disabled={isFirstPhase}>
+                  <FastRewindIcon />
+                </Button>
+              </ConditionalTooltip>
+              <ConditionalTooltip condition={phaseConfig.type === "count"} title={isPaused ? "再開" : "一時停止"}>
+                <Button onClick={onPauseButton} disabled={phaseConfig.type !== "count"}>
+                  {
+                    isPaused ? <PlayArrowIcon /> : <PauseIcon />
+                  }
+                </Button>
+              </ConditionalTooltip>
+              <ConditionalTooltip condition={!isLastPhase} title="次のフェーズに">
+                <Button onClick={onNextPhase} disabled={isLastPhase}>
+                  <FastForwardIcon />
+                </Button>
+              </ConditionalTooltip>
+              <ConditionalTooltip condition={!isLastPhase} title="最初のフェーズに">
+                <Button onClick={onLastPhase} disabled={isLastPhase}>
+                  <SkipNextIcon />
+                </Button>
+              </ConditionalTooltip>
             </ButtonGroup>
           </Grid>
-          {isPaused && <Grid item xs={12} sx={{ 
+          {isPaused && <Grid item xs={12} sx={{
             display: 'flex',
             justifyContent: 'center',
-           }}>
-            <ButtonGroup size="small" sx={{ 
+          }}>
+            <ButtonGroup size="small" variant="text" color="inherit" sx={{
               opacity: 0.8,
               transition: '0.3s',
-             }}>
-              <Tooltip title="-10s">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onTimeChange(-10 * 1000)} disabled={isFirstPhase}>
-                    <Replay10Icon />
-                  </Button>
-                </span>
-              </Tooltip>
-              <Tooltip title="-1s">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onTimeChange(-1 * 1000)} disabled={isFirstPhase}>
-                    <RemoveIcon />
-                  </Button>
-                </span>
-              </Tooltip>
-              <LabelInButtonGroup>
-                {pausedElapsedSecond ? `${pausedElapsedSecond} s` : "ー"} 
-              </LabelInButtonGroup>
-              <Tooltip title="+1s">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onTimeChange(+1 * 1000)} disabled={isLastPhase}>
-                    <AddIcon />
-                  </Button>
-                </span>
-              </Tooltip>
-              <Tooltip title="+10s">
-                <span>
-                  <Button variant="contained" color="grey" onClick={onTimeChange(+10 * 1000)} disabled={isLastPhase}>
-                    <Forward10Icon />
-                  </Button>
-                </span>
-              </Tooltip>
+              border: '1px solid rgba(0, 0, 0, 0.23)',
+            }}>
+              <Button onClick={onTimeChange(-10 * 1000)} disabled={isFirstPhase}>
+                -10
+              </Button>
+              <Button onClick={onTimeChange(-1 * 1000)} disabled={isFirstPhase}>
+                -1
+              </Button>
+              <Button sx={{
+                width: "6rem",
+                fontSize: '1rem',
+                textTransform: 'none',
+              }}>
+                {pausedElapsedSecond ? `${pausedElapsedSecond} s` : "ー"}
+              </Button>
+              <Button onClick={onTimeChange(+1 * 1000)} disabled={isLastPhase}>
+                +1
+              </Button>
+              <Button onClick={onTimeChange(+10 * 1000)} disabled={isLastPhase}>
+                +10
+              </Button>
             </ButtonGroup>
           </Grid>}
         </Grid>
@@ -187,21 +162,5 @@ export const TimerMasterComponent: FC<TimerMasterComponentProps> = ({
         </Grid>
       </Grid>
     </Paper>
-  );
-}
-
-const LabelInButtonGroup = (props: { children: React.ReactNode }) => {
-  return (
-    <Box sx={{ 
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      paddingLeft: 1,
-      paddingRight: 1,
-      cursor: 'default',
-      boxShadow: '0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)',
-     }}>
-      {props.children}
-    </Box>
   );
 }

--- a/client/src/components/TimerMasterComponent.tsx
+++ b/client/src/components/TimerMasterComponent.tsx
@@ -1,15 +1,20 @@
 import { FC } from 'react';
-import { Paper, Typography, Grid, Button, ButtonGroup, Tooltip } from '@mui/material';
+import { Paper, Typography, Grid, Button, ButtonGroup, Tooltip, Box } from '@mui/material';
 import PauseIcon from '@mui/icons-material/Pause';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import SkipPreviousIcon from '@mui/icons-material/SkipPrevious';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import FastRewindIcon from '@mui/icons-material/FastRewind';
 import FastForwardIcon from '@mui/icons-material/FastForward';
+import Forward10Icon from '@mui/icons-material/Forward10';
+import Replay10Icon from '@mui/icons-material/Replay10';
+import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
 import { TimerDisplay } from './TimerDisplay';
 import { TimeProgressConfigType } from '@/config/types';
 import styled from '@emotion/styled';
 import { CurrentPhaseState } from '@/slices/phase';
+import { Label } from '@mui/icons-material';
 
 const DetailInfoUl = styled('ul')({
   paddingInlineStart: '22px',
@@ -20,16 +25,17 @@ const DetailInfoHead = styled('span')({
   paddingRight: '.5em',
 });
 
-
 interface TimerMasterComponentProps {
   isFirstPhase: boolean,
   isLastPhase: boolean,
   isPaused: boolean,
+  pausedElapsedSecond?: number,
   onFirstPhase: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void,
   onPrevPhase: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void,
   onPauseButton: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void,
   onNextPhase: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void,
   onLastPhase: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void,
+  onTimeChange: (ms: number) => (event: React.MouseEvent<HTMLElement, MouseEvent>) => void,
   isEnabledNextButton: boolean,
   phaseConfig: TimeProgressConfigType,
   currentPhaseState: CurrentPhaseState,
@@ -39,11 +45,13 @@ export const TimerMasterComponent: FC<TimerMasterComponentProps> = ({
   isFirstPhase,
   isLastPhase,
   isPaused,
+  pausedElapsedSecond,
   onFirstPhase,
   onPrevPhase,
   onPauseButton,
   onNextPhase,
   onLastPhase,
+  onTimeChange,
   isEnabledNextButton,
   phaseConfig,
 }) => {
@@ -110,6 +118,47 @@ export const TimerMasterComponent: FC<TimerMasterComponentProps> = ({
               </Tooltip>
             </ButtonGroup>
           </Grid>
+          {isPaused && <Grid item xs={12} sx={{ 
+            display: 'flex',
+            justifyContent: 'center',
+           }}>
+            <ButtonGroup size="small" sx={{ 
+              opacity: 0.8,
+              transition: '0.3s',
+             }}>
+              <Tooltip title="-10s">
+                <span>
+                  <Button variant="contained" color="grey" onClick={onTimeChange(-10 * 1000)} disabled={isFirstPhase}>
+                    <Replay10Icon />
+                  </Button>
+                </span>
+              </Tooltip>
+              <Tooltip title="-1s">
+                <span>
+                  <Button variant="contained" color="grey" onClick={onTimeChange(-1 * 1000)} disabled={isFirstPhase}>
+                    <RemoveIcon />
+                  </Button>
+                </span>
+              </Tooltip>
+              <LabelInButtonGroup>
+                {pausedElapsedSecond ? `${pausedElapsedSecond} s` : "ー"} 
+              </LabelInButtonGroup>
+              <Tooltip title="+1s">
+                <span>
+                  <Button variant="contained" color="grey" onClick={onTimeChange(+1 * 1000)} disabled={isLastPhase}>
+                    <AddIcon />
+                  </Button>
+                </span>
+              </Tooltip>
+              <Tooltip title="+10s">
+                <span>
+                  <Button variant="contained" color="grey" onClick={onTimeChange(+10 * 1000)} disabled={isLastPhase}>
+                    <Forward10Icon />
+                  </Button>
+                </span>
+              </Tooltip>
+            </ButtonGroup>
+          </Grid>}
         </Grid>
         <Grid item xs={4}>
           <Button
@@ -138,5 +187,21 @@ export const TimerMasterComponent: FC<TimerMasterComponentProps> = ({
         </Grid>
       </Grid>
     </Paper>
+  );
+}
+
+const LabelInButtonGroup = (props: { children: React.ReactNode }) => {
+  return (
+    <Box sx={{ 
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingLeft: 1,
+      paddingRight: 1,
+      cursor: 'default',
+      boxShadow: '0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)',
+     }}>
+      {props.children}
+    </Box>
   );
 }

--- a/client/src/components/TimerMasterContainer.tsx
+++ b/client/src/components/TimerMasterContainer.tsx
@@ -90,6 +90,15 @@ export const TimerMasterContainer: FC = () => {
       })]);
     }
   }, [currentPhase, timeOffset]);
+  const onTimeChange = useCallback((ms: number) => () => {
+    const startTime = currentPhase.startTime - ms;
+    LyricalSocket.dispatchAll([phaseStateSlice.actions.setState({
+      id: currentPhase.id,
+      startTime,
+      pausedTime: currentPhase.pausedTime,
+    })]);
+  }, [currentPhase]);
+  const pausedElapsedSecond = currentPhase.pausedTime ? (currentPhase.pausedTime - currentPhase.startTime) / 1000 : undefined;
 
   useEffect(() => {
     // タイマーの更新時にフェーズ移行を確認
@@ -105,11 +114,13 @@ export const TimerMasterContainer: FC = () => {
       isFirstPhase={Phase.getIndex(phaseState.current.id) === 0}
       isLastPhase={Phase.isLast(phaseState.current.id)}
       isPaused={phaseState.current.pausedTime !== undefined}
+      pausedElapsedSecond={pausedElapsedSecond}
       onFirstPhase={onFirstPhase}
       onPrevPhase={onPrevPhase}
       onNextPhase={onNextPhase}
       onLastPhase={onLastPhase}
       onPauseButton={onPauseButton}
+      onTimeChange={onTimeChange}
       isEnabledNextButton={isEnabledNextButton}
       phaseConfig={Phase.getRawConfig(phaseState.current.id)}
       currentPhaseState={phaseState.current}

--- a/client/src/ui/ConditionalTooltip.tsx
+++ b/client/src/ui/ConditionalTooltip.tsx
@@ -1,0 +1,19 @@
+import { Tooltip, TooltipProps } from '@mui/material';
+
+type ConditionalTooltipProp = TooltipProps & {
+  condition?: boolean,
+};
+
+export const ConditionalTooltip = ({
+  condition,
+  children,
+  ...rest
+}: ConditionalTooltipProp) => (
+  condition ? (
+    <Tooltip {...rest}>
+      {children}
+    </Tooltip>
+  ) : (
+    <>{children}</>
+  )
+);

--- a/client/src/util/formatTime.ts
+++ b/client/src/util/formatTime.ts
@@ -36,3 +36,12 @@ export const parseFormatTime = (time: string): number => {
   }
   throw new Error("Invalid time format");
 };
+
+// Unix時刻をミリ秒まで含めた `23:59:01.234` 形式の日時にする
+export const unixToTimeWithMillis = (unixtime: number): string => {
+  const date = new Date(unixtime);
+  const hhmmss = date.toLocaleTimeString('sv-SE');
+  const ms = (date.getMilliseconds() % 1000).toString().padStart(3, '0');
+
+  return `${hhmmss}.${ms}`;
+}


### PR DESCRIPTION
### 機能追加

- タイマー停止時に、経過時間を変更（-10s/-1s/+1s/+10s）できるようにした
- フェイルセーフな実装にはなっていないので要注意（-10sを連打してマイナス時間にできる）

### UI変更

- 今までタイマーのすぐ下にあったフェーズ操作を、右側に
- 時間操作UIを常時表示（一時停止時のみ有効）に
- デバッグ用の情報を減らして、目立たないように変更