### PR TITLE
スクリーン画面と配信オーバーレイ画面のコンポーネントを整理

### DIFF
--- a/packages/client/src/AppMuiThemeProvider.tsx
+++ b/packages/client/src/AppMuiThemeProvider.tsx
@@ -5,6 +5,7 @@ import {
   createTheme,
   alpha,
 } from '@mui/material/styles';
+import { CssBaseline } from '@mui/material';
 import { blue, grey, pink } from '@mui/material/colors';
 import '@fontsource/noto-sans-jp/index.css';
 
@@ -88,6 +89,7 @@ type Props = {
 export const AppMuiThemeProvider = ({ children }: Props) => {
   return (
     <StyledEngineProvider injectFirst>
+      <CssBaseline />
       <ThemeProvider theme={appTheme}>{children}</ThemeProvider>
     </StyledEngineProvider>
   );

--- a/packages/client/src/components/Dashboard.tsx
+++ b/packages/client/src/components/Dashboard.tsx
@@ -6,7 +6,6 @@ import {
   Drawer as MuiDrawer,
   Box,
   Container,
-  CssBaseline,
   Divider,
   IconButton,
   List,
@@ -106,7 +105,6 @@ export const Dashboard: FC<DashboardProps> = ({ children, title }) => {
 
   return (
     <Box sx={{ display: 'flex' }}>
-      <CssBaseline />
       <AppBar color="default" position="absolute" open={open}>
         <Toolbar
           sx={{

--- a/packages/client/src/components/Screen/ScoreBoard.tsx
+++ b/packages/client/src/components/Screen/ScoreBoard.tsx
@@ -1,0 +1,82 @@
+import { Box } from '@mui/material';
+import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
+import { RootState } from '@/slices';
+import { useSelector } from 'react-redux';
+import { useDisplayScore } from '@/functional/useDisplayScore';
+import { formatTime } from '@/util/formatTime';
+import { config } from '@/config/load';
+
+type ScoreBoardProps = {
+  fieldSide: "blue" | "red",
+  placement: "left" | "right",
+};
+
+export const ScoreBoard = ({
+  fieldSide,
+}: ScoreBoardProps) => {
+
+  const teamName = useSelector<RootState, string>((state) => state.match.teams[fieldSide]?.shortName ?? "");
+  const { value, scoreState } = useDisplayScore(fieldSide);
+  const color = fieldSide == "blue" ? "rgba(0, 0, 250, 0.9)" : "rgba(250, 0, 0, 0.9)";
+
+  return (
+    <Box sx={{
+      width: '100%',
+      height: '180px',
+      border: '2px solid',
+      borderColor: color,
+      textAlign: 'center',
+    }}>
+      <Box sx={{
+        backgroundColor: color,
+        color: 'rgb(240, 240, 240)',
+        height: '60px',
+        lineHeight: '65px',
+        fontSize: '0.7em',
+        px: '0.5em',
+      }}>
+        {teamName}
+      </Box>
+      <Box sx={{
+        height: '120px',
+        fontSize: '1.5em',
+        backgroundColor: 'rgba(255, 255, 255, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-evenly',
+        flexDirection: 'row',
+      }}>
+        <Box>
+          {value}
+        </Box>
+        {scoreState.vgoal && (
+          <Box sx={{
+            fontSize: "40%",
+            ml: 1,
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            gap: 1,
+          }}>
+            <Box sx={{
+              lineHeight: 1,
+              maxHeight: "45%",
+            }}>
+              {config.rule.vgoal.name}
+            </Box>
+            <Box sx={{
+              maxHeight: "45%",
+              display: "flex",
+              flexDirection: "row",
+              alignItems: "center",
+              gap: 1,
+            }}>
+              <TimerOutlinedIcon sx={{ pt: 0.5, fontSize: "120%", color: "rgba(80, 80, 80, 0.9)", textAnchor: "middle" }} />
+              {formatTime(scoreState.vgoal, "m:ss")}
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/packages/client/src/components/Screen/ScoreBoard.tsx
+++ b/packages/client/src/components/Screen/ScoreBoard.tsx
@@ -1,78 +1,95 @@
 import { Box } from '@mui/material';
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
-import { RootState } from '@/slices';
+import type { RootState } from '@/slices';
 import { useSelector } from 'react-redux';
 import { useDisplayScore } from '@/functional/useDisplayScore';
 import { formatTime } from '@/util/formatTime';
 import { config } from '@/config/load';
 
 type ScoreBoardProps = {
-  fieldSide: "blue" | "red",
-  placement: "left" | "right",
+  fieldSide: 'blue' | 'red';
+  placement: 'left' | 'right';
 };
 
-export const ScoreBoard = ({
-  fieldSide,
-}: ScoreBoardProps) => {
-
-  const teamName = useSelector<RootState, string>((state) => state.match.teams[fieldSide]?.shortName ?? "");
+export const ScoreBoard = ({ fieldSide }: ScoreBoardProps) => {
+  const teamName = useSelector<RootState, string>(
+    (state) => state.match.teams[fieldSide]?.shortName ?? '',
+  );
   const { value, scoreState } = useDisplayScore(fieldSide);
-  const color = fieldSide == "blue" ? "rgba(0, 0, 250, 0.9)" : "rgba(250, 0, 0, 0.9)";
+  const color =
+    fieldSide === 'blue' ? 'rgba(0, 0, 250, 0.9)' : 'rgba(250, 0, 0, 0.9)';
 
   return (
-    <Box sx={{
-      width: '100%',
-      height: '180px',
-      border: '2px solid',
-      borderColor: color,
-      textAlign: 'center',
-    }}>
-      <Box sx={{
-        backgroundColor: color,
-        color: 'rgb(240, 240, 240)',
-        height: '60px',
-        lineHeight: '65px',
-        fontSize: '0.7em',
-        px: '0.5em',
-      }}>
+    <Box
+      sx={{
+        width: '100%',
+        height: '180px',
+        border: '2px solid',
+        borderColor: color,
+        textAlign: 'center',
+      }}
+    >
+      <Box
+        sx={{
+          backgroundColor: color,
+          color: 'rgb(240, 240, 240)',
+          height: '60px',
+          lineHeight: '65px',
+          fontSize: '0.7em',
+          px: '0.5em',
+        }}
+      >
         {teamName}
       </Box>
-      <Box sx={{
-        height: '120px',
-        fontSize: '1.5em',
-        backgroundColor: 'rgba(255, 255, 255, 0.6)',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-evenly',
-        flexDirection: 'row',
-      }}>
-        <Box>
-          {value}
-        </Box>
+      <Box
+        sx={{
+          height: '120px',
+          fontSize: '1.5em',
+          backgroundColor: 'rgba(255, 255, 255, 0.6)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-evenly',
+          flexDirection: 'row',
+        }}
+      >
+        <Box>{value}</Box>
         {scoreState.vgoal && (
-          <Box sx={{
-            fontSize: "40%",
-            ml: 1,
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            gap: 1,
-          }}>
-            <Box sx={{
-              lineHeight: 1,
-              maxHeight: "45%",
-            }}>
+          <Box
+            sx={{
+              fontSize: '40%',
+              ml: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              gap: 1,
+            }}
+          >
+            <Box
+              sx={{
+                lineHeight: 1,
+                maxHeight: '45%',
+              }}
+            >
               {config.rule.vgoal.name}
             </Box>
-            <Box sx={{
-              maxHeight: "45%",
-              display: "flex",
-              flexDirection: "row",
-              alignItems: "center",
-              gap: 1,
-            }}>
-              <TimerOutlinedIcon sx={{ pt: 0.5, fontSize: "120%", color: "rgba(80, 80, 80, 0.9)", textAnchor: "middle" }} />
-              {formatTime(scoreState.vgoal, "m:ss")}
+            <Box
+              sx={{
+                maxHeight: '45%',
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 1,
+              }}
+            >
+              <TimerOutlinedIcon
+                sx={{
+                  pt: 0.5,
+                  fontSize: '120%',
+                  color: 'rgba(80, 80, 80, 0.9)',
+                  textAnchor: 'middle',
+                }}
+              />
+              {formatTime(scoreState.vgoal, 'm:ss')}
             </Box>
           </Box>
         )}

--- a/packages/client/src/components/Screen/ScoreBoard.tsx
+++ b/packages/client/src/components/Screen/ScoreBoard.tsx
@@ -1,10 +1,10 @@
 import { Box } from '@mui/material';
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
-import type { RootState } from '@/slices';
+import type { RootState } from '@rolimoa/common/redux';
 import { useSelector } from 'react-redux';
 import { useDisplayScore } from '@/functional/useDisplayScore';
 import { formatTime } from '@/util/formatTime';
-import { config } from '@/config/load';
+import { config } from '@rolimoa/common/config';
 
 type ScoreBoardProps = {
   fieldSide: 'blue' | 'red';

--- a/packages/client/src/components/Screen/TimerDisplay.tsx
+++ b/packages/client/src/components/Screen/TimerDisplay.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import type { RootState } from '@/slices';
+import type { RootState } from '@rolimoa/common/redux';
 import { Box, type SxProps } from '@mui/material';
 import type { Theme } from '@emotion/react';
 import { useDisplayTimer } from '@/functional/useDisplayTimer';

--- a/packages/client/src/components/Screen/TimerDisplay.tsx
+++ b/packages/client/src/components/Screen/TimerDisplay.tsx
@@ -1,0 +1,58 @@
+import { useSelector } from 'react-redux';
+import { RootState } from '@/slices';
+import { Box, SxProps } from '@mui/material';
+import { Theme } from '@emotion/react';
+import { useDisplayTimer } from '@/functional/useDisplayTimer';
+
+const textShadow = (px: number, color = "#FFF") => `${px}px ${px}px 0 ${color}, -${px}px -${px}px 0 ${color}, -${px}px ${px}px 0 ${color}, ${px}px -${px}px 0 ${color}, 0px ${px}px 0 ${color},  0-${px}px 0 ${color}, -${px}px 0 0 ${color}, ${px}px 0 0 ${color}`;
+
+type TimerDisplayProps = {
+  sxContainer?: SxProps<Theme>,
+  sxMatchName?: SxProps<Theme>,
+  sxDescription?: SxProps<Theme>,
+  sxTime?: SxProps<Theme>,
+};
+
+export const TimerDisplay = ({
+  sxContainer = {},
+  sxMatchName = {},
+  sxDescription = {},
+  sxTime = {},
+}: TimerDisplayProps) => {
+  const { description, displayTime } = useDisplayTimer();
+  const matchName = useSelector<RootState, string>((state) => state.match.name);
+
+  return <>
+    <Box sx={{
+      width: '100%',
+      textAlign: 'center',
+      boxSizing: 'border-box',
+      ...sxContainer,
+    }}>
+      <Box sx={{
+        fontSize: '1em',
+        textShadow: textShadow(1),
+        ...sxMatchName,
+      }}>
+        {matchName || "\u00A0"}
+      </Box>
+      <Box sx={{
+        fontSize: '0.6em',
+        textShadow: textShadow(1),
+        ...sxDescription,
+      }}>
+        {description || "\u00A0"}
+      </Box>
+      <Box sx={{
+        fontFamily: "DSEG14-Classic",
+        fontWeight: 500,
+        fontSize: '4em',
+        pt: '0.1em',
+        textShadow: textShadow(8),
+        ...sxTime,
+      }}>
+        {displayTime}
+      </Box>
+    </Box>
+  </>;
+};

--- a/packages/client/src/components/Screen/TimerDisplay.tsx
+++ b/packages/client/src/components/Screen/TimerDisplay.tsx
@@ -1,16 +1,17 @@
 import { useSelector } from 'react-redux';
-import { RootState } from '@/slices';
-import { Box, SxProps } from '@mui/material';
-import { Theme } from '@emotion/react';
+import type { RootState } from '@/slices';
+import { Box, type SxProps } from '@mui/material';
+import type { Theme } from '@emotion/react';
 import { useDisplayTimer } from '@/functional/useDisplayTimer';
 
-const textShadow = (px: number, color = "#FFF") => `${px}px ${px}px 0 ${color}, -${px}px -${px}px 0 ${color}, -${px}px ${px}px 0 ${color}, ${px}px -${px}px 0 ${color}, 0px ${px}px 0 ${color},  0-${px}px 0 ${color}, -${px}px 0 0 ${color}, ${px}px 0 0 ${color}`;
+const textShadow = (px: number, color = '#FFF') =>
+  `${px}px ${px}px 0 ${color}, -${px}px -${px}px 0 ${color}, -${px}px ${px}px 0 ${color}, ${px}px -${px}px 0 ${color}, 0px ${px}px 0 ${color},  0-${px}px 0 ${color}, -${px}px 0 0 ${color}, ${px}px 0 0 ${color}`;
 
 type TimerDisplayProps = {
-  sxContainer?: SxProps<Theme>,
-  sxMatchName?: SxProps<Theme>,
-  sxDescription?: SxProps<Theme>,
-  sxTime?: SxProps<Theme>,
+  sxContainer?: SxProps<Theme>;
+  sxMatchName?: SxProps<Theme>;
+  sxDescription?: SxProps<Theme>;
+  sxTime?: SxProps<Theme>;
 };
 
 export const TimerDisplay = ({
@@ -22,37 +23,47 @@ export const TimerDisplay = ({
   const { description, displayTime } = useDisplayTimer();
   const matchName = useSelector<RootState, string>((state) => state.match.name);
 
-  return <>
-    <Box sx={{
-      width: '100%',
-      textAlign: 'center',
-      boxSizing: 'border-box',
-      ...sxContainer,
-    }}>
-      <Box sx={{
-        fontSize: '1em',
-        textShadow: textShadow(1),
-        ...sxMatchName,
-      }}>
-        {matchName || "\u00A0"}
+  return (
+    <>
+      <Box
+        sx={{
+          width: '100%',
+          textAlign: 'center',
+          boxSizing: 'border-box',
+          ...sxContainer,
+        }}
+      >
+        <Box
+          sx={{
+            fontSize: '1em',
+            textShadow: textShadow(1),
+            ...sxMatchName,
+          }}
+        >
+          {matchName || '\u00A0'}
+        </Box>
+        <Box
+          sx={{
+            fontSize: '0.6em',
+            textShadow: textShadow(1),
+            ...sxDescription,
+          }}
+        >
+          {description || '\u00A0'}
+        </Box>
+        <Box
+          sx={{
+            fontFamily: 'DSEG14-Classic',
+            fontWeight: 500,
+            fontSize: '4em',
+            pt: '0.1em',
+            textShadow: textShadow(8),
+            ...sxTime,
+          }}
+        >
+          {displayTime}
+        </Box>
       </Box>
-      <Box sx={{
-        fontSize: '0.6em',
-        textShadow: textShadow(1),
-        ...sxDescription,
-      }}>
-        {description || "\u00A0"}
-      </Box>
-      <Box sx={{
-        fontFamily: "DSEG14-Classic",
-        fontWeight: 500,
-        fontSize: '4em',
-        pt: '0.1em',
-        textShadow: textShadow(8),
-        ...sxTime,
-      }}>
-        {displayTime}
-      </Box>
-    </Box>
-  </>;
+    </>
+  );
 };

--- a/packages/client/src/components/Screen/Underlay.tsx
+++ b/packages/client/src/components/Screen/Underlay.tsx
@@ -1,7 +1,15 @@
-import { Box } from "@mui/material";
+import { Box } from '@mui/material';
 
 export const Underlay = () => (
-  <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", fontSize: "100px", height: "100%" }}>
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      fontSize: '100px',
+      height: '100%',
+    }}
+  >
     {/* ここに下要素(試合状況を分かりやすくするカスタマイズ)を実装 */}
   </Box>
 );

--- a/packages/client/src/components/Screen/Underlay.tsx
+++ b/packages/client/src/components/Screen/Underlay.tsx
@@ -1,0 +1,7 @@
+import { Box } from "@mui/material";
+
+export const Underlay = () => (
+  <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", fontSize: "100px", height: "100%" }}>
+    {/* ここに下要素(試合状況を分かりやすくするカスタマイズ)を実装 */}
+  </Box>
+);

--- a/packages/client/src/components/StreamingOverlay/TimerDisplay.tsx
+++ b/packages/client/src/components/StreamingOverlay/TimerDisplay.tsx
@@ -1,0 +1,78 @@
+import { Ref } from 'react';
+import { useSelector } from 'react-redux';
+import { Box, Divider, SxProps } from '@mui/material';
+import { RootState } from '@/slices';
+import { useDisplayTimer } from '@/functional/useDisplayTimer';
+import { Theme } from '@emotion/react';
+
+type ScoreDisplayProps = {
+  ref?: Ref<HTMLDivElement>,
+  sxContainer?: SxProps<Theme>,
+  sxDescription?: SxProps<Theme>,
+  sxTime?: SxProps<Theme>,
+  sxDivider?: SxProps<Theme>,
+  sxMatchName?: SxProps<Theme>,
+};
+
+export const TimerDisplay = ({
+  ref,
+  sxContainer = {},
+  sxDescription = {},
+  sxTime = {},
+  sxDivider = {},
+  sxMatchName = {},
+}: ScoreDisplayProps) => {
+  const { description, displayTime } = useDisplayTimer();
+  const matchName = useSelector<RootState, string>((state) => state.match.name);
+
+  return (
+    <Box ref={ref} sx={{
+      width: '400px',
+      height: '260px',
+      textAlign: 'center',
+      backgroundColor: 'rgba(10, 10, 10, 0.9)',
+      boxSizing: 'border-box',
+      color: 'rgba(240, 240, 240, 0.95)',
+      zIndex: 10,
+      fontSize: '24px',
+      ...sxContainer,
+    }}>
+      <Box sx={{
+        height: '70px',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        ...sxDescription,
+      }}>
+        {description}
+      </Box>
+      <Box sx={{
+        height: '120px',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        fontFamily: "DSEG14-Classic",
+        fontWeight: 500,
+        fontSize: '300%',
+        ...sxTime,
+      }}>
+        {displayTime}
+      </Box>
+      <Divider sx={{
+        margin: '0 30px',
+        borderColor: 'rgba(240, 240, 240, 0.5)',
+        ...sxDivider,
+      }}/>
+      <Box sx={{
+        height: '68px',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        whiteSpace: 'nowrap',
+        ...sxMatchName,
+      }}>
+        {matchName ?? ""}
+      </Box>
+    </Box>
+  );
+};

--- a/packages/client/src/components/StreamingOverlay/TimerDisplay.tsx
+++ b/packages/client/src/components/StreamingOverlay/TimerDisplay.tsx
@@ -1,17 +1,17 @@
-import { Ref } from 'react';
+import type { Ref } from 'react';
 import { useSelector } from 'react-redux';
-import { Box, Divider, SxProps } from '@mui/material';
-import { RootState } from '@/slices';
+import { Box, Divider, type SxProps } from '@mui/material';
+import type { RootState } from '@/slices';
 import { useDisplayTimer } from '@/functional/useDisplayTimer';
-import { Theme } from '@emotion/react';
+import type { Theme } from '@emotion/react';
 
 type ScoreDisplayProps = {
-  ref?: Ref<HTMLDivElement>,
-  sxContainer?: SxProps<Theme>,
-  sxDescription?: SxProps<Theme>,
-  sxTime?: SxProps<Theme>,
-  sxDivider?: SxProps<Theme>,
-  sxMatchName?: SxProps<Theme>,
+  ref?: Ref<HTMLDivElement>;
+  sxContainer?: SxProps<Theme>;
+  sxDescription?: SxProps<Theme>;
+  sxTime?: SxProps<Theme>;
+  sxDivider?: SxProps<Theme>;
+  sxMatchName?: SxProps<Theme>;
 };
 
 export const TimerDisplay = ({
@@ -26,52 +26,63 @@ export const TimerDisplay = ({
   const matchName = useSelector<RootState, string>((state) => state.match.name);
 
   return (
-    <Box ref={ref} sx={{
-      width: '400px',
-      height: '260px',
-      textAlign: 'center',
-      backgroundColor: 'rgba(10, 10, 10, 0.9)',
-      boxSizing: 'border-box',
-      color: 'rgba(240, 240, 240, 0.95)',
-      zIndex: 10,
-      fontSize: '24px',
-      ...sxContainer,
-    }}>
-      <Box sx={{
-        height: '70px',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        ...sxDescription,
-      }}>
+    <Box
+      ref={ref}
+      sx={{
+        width: '400px',
+        height: '260px',
+        textAlign: 'center',
+        backgroundColor: 'rgba(10, 10, 10, 0.9)',
+        boxSizing: 'border-box',
+        color: 'rgba(240, 240, 240, 0.95)',
+        zIndex: 10,
+        fontSize: '24px',
+        ...sxContainer,
+      }}
+    >
+      <Box
+        sx={{
+          height: '70px',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          ...sxDescription,
+        }}
+      >
         {description}
       </Box>
-      <Box sx={{
-        height: '120px',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        fontFamily: "DSEG14-Classic",
-        fontWeight: 500,
-        fontSize: '300%',
-        ...sxTime,
-      }}>
+      <Box
+        sx={{
+          height: '120px',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          fontFamily: 'DSEG14-Classic',
+          fontWeight: 500,
+          fontSize: '300%',
+          ...sxTime,
+        }}
+      >
         {displayTime}
       </Box>
-      <Divider sx={{
-        margin: '0 30px',
-        borderColor: 'rgba(240, 240, 240, 0.5)',
-        ...sxDivider,
-      }}/>
-      <Box sx={{
-        height: '68px',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        whiteSpace: 'nowrap',
-        ...sxMatchName,
-      }}>
-        {matchName ?? ""}
+      <Divider
+        sx={{
+          margin: '0 30px',
+          borderColor: 'rgba(240, 240, 240, 0.5)',
+          ...sxDivider,
+        }}
+      />
+      <Box
+        sx={{
+          height: '68px',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          whiteSpace: 'nowrap',
+          ...sxMatchName,
+        }}
+      >
+        {matchName ?? ''}
       </Box>
     </Box>
   );

--- a/packages/client/src/components/StreamingOverlay/TimerDisplay.tsx
+++ b/packages/client/src/components/StreamingOverlay/TimerDisplay.tsx
@@ -1,7 +1,7 @@
 import type { Ref } from 'react';
 import { useSelector } from 'react-redux';
 import { Box, Divider, type SxProps } from '@mui/material';
-import type { RootState } from '@/slices';
+import type { RootState } from '@rolimoa/common/redux';
 import { useDisplayTimer } from '@/functional/useDisplayTimer';
 import type { Theme } from '@emotion/react';
 

--- a/packages/client/src/components/StreamingOverlay/gameLike/ScoreSubDisplay.tsx
+++ b/packages/client/src/components/StreamingOverlay/gameLike/ScoreSubDisplay.tsx
@@ -1,0 +1,19 @@
+import { Box } from '@mui/material';
+import { FieldSideType } from '@/slices/score';
+import { useCurrentMatchState } from '@/functional/useCurrentMatchState';
+
+type ScoreSubDisplayProps = {
+  fieldSide: FieldSideType,
+  placement: "left" | "right",
+};
+
+export const ScoreSubDisplay = ({ fieldSide }: ScoreSubDisplayProps) => {
+  // @ts-expect-error TS6133 (このコメントは実装時に削除してください)
+  const { taskObjects } = useCurrentMatchState(fieldSide); 
+
+  return (
+    <Box sx={{ lineHeight: "135px" }}>
+      ここに実装
+    </Box>
+  );
+};

--- a/packages/client/src/components/StreamingOverlay/gameLike/ScoreSubDisplay.tsx
+++ b/packages/client/src/components/StreamingOverlay/gameLike/ScoreSubDisplay.tsx
@@ -1,19 +1,15 @@
 import { Box } from '@mui/material';
-import { FieldSideType } from '@/slices/score';
+import type { FieldSideType } from '@/slices/score';
 import { useCurrentMatchState } from '@/functional/useCurrentMatchState';
 
 type ScoreSubDisplayProps = {
-  fieldSide: FieldSideType,
-  placement: "left" | "right",
+  fieldSide: FieldSideType;
+  placement: 'left' | 'right';
 };
 
 export const ScoreSubDisplay = ({ fieldSide }: ScoreSubDisplayProps) => {
   // @ts-expect-error TS6133 (このコメントは実装時に削除してください)
-  const { taskObjects } = useCurrentMatchState(fieldSide); 
+  const { taskObjects } = useCurrentMatchState(fieldSide);
 
-  return (
-    <Box sx={{ lineHeight: "135px" }}>
-      ここに実装
-    </Box>
-  );
+  return <Box sx={{ lineHeight: '135px' }}>ここに実装</Box>;
 };

--- a/packages/client/src/components/StreamingOverlay/gameLike/ScoreSubDisplay.tsx
+++ b/packages/client/src/components/StreamingOverlay/gameLike/ScoreSubDisplay.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@mui/material';
-import type { FieldSideType } from '@/slices/score';
+import type { FieldSideType } from '@rolimoa/common/redux';
 import { useCurrentMatchState } from '@/functional/useCurrentMatchState';
 
 type ScoreSubDisplayProps = {

--- a/packages/client/src/components/StreamingOverlay/gameLike/index.tsx
+++ b/packages/client/src/components/StreamingOverlay/gameLike/index.tsx
@@ -3,8 +3,8 @@ import { Box } from '@mui/material';
 import TimerIcon from '@mui/icons-material/Timer';
 import { CenterFlex } from '@/ui/CenterFlex';
 import { SlideTransition } from '@/ui/SlideTransition';
-import { RootState } from '@/slices';
-import { FieldSideType } from '@/slices/score';
+import type { RootState } from '@/slices';
+import type { FieldSideType } from '@/slices/score';
 import { useDisplayScore } from '@/functional/useDisplayScore';
 import { formatTime } from '@/util/formatTime';
 import { config } from '@/config/load';
@@ -12,14 +12,17 @@ import { TimerDisplay } from '../TimerDisplay';
 import { ScoreSubDisplay } from './ScoreSubDisplay';
 
 const ScoreBlock = (props: {
-  fieldSide: FieldSideType,
-  placement: "left" | "right",
+  fieldSide: FieldSideType;
+  placement: 'left' | 'right';
 }) => {
   const { fieldSide, placement } = props;
-  const teamName = useSelector<RootState, string | undefined>((state) => state.match.teams[fieldSide]?.shortName);
+  const teamName = useSelector<RootState, string | undefined>(
+    (state) => state.match.teams[fieldSide]?.shortName,
+  );
   const displayScore = useDisplayScore(fieldSide);
 
-  const color = fieldSide == "blue" ? "rgba(0, 0, 240, 0.8)" : "rgba(240, 0, 0, 0.8)";
+  const color =
+    fieldSide === 'blue' ? 'rgba(0, 0, 240, 0.8)' : 'rgba(240, 0, 0, 0.8)';
 
   const containerHeight = 260;
   const nameBlockHeight = 55;
@@ -28,92 +31,112 @@ const ScoreBlock = (props: {
 
   return (
     <Box>
-      <Box sx={{
-        width: '600px',
-        height: `${containerHeight}px`,
-        textAlign: 'center',
-        backgroundColor: 'rgba(240, 240, 240, 0.8)',
-        clipPath: 'polygon(0 0, 0 100%, 30% 100%, 50% 190px, 100% 190px, 100% 0)',
-        transform: placement === "left" ? '' : 'scaleX(-1)',
-      }}>
-        <Box sx={{
-          height: `${nameBlockHeight}px`,
-          lineHeight: `${nameBlockHeight + 2}px`, // ちょっと調整
-          backgroundColor: color,
-          fontSize: `${teamNameFontSize}px`,
-          color: "rgba(255, 255, 255, 0.9)",
-          transform: placement === "left" ? '' : 'scaleX(-1)',
-        }}>
-          {teamName ?? " "}
+      <Box
+        sx={{
+          width: '600px',
+          height: `${containerHeight}px`,
+          textAlign: 'center',
+          backgroundColor: 'rgba(240, 240, 240, 0.8)',
+          clipPath:
+            'polygon(0 0, 0 100%, 30% 100%, 50% 190px, 100% 190px, 100% 0)',
+          transform: placement === 'left' ? '' : 'scaleX(-1)',
+        }}
+      >
+        <Box
+          sx={{
+            height: `${nameBlockHeight}px`,
+            lineHeight: `${nameBlockHeight + 2}px`, // ちょっと調整
+            backgroundColor: color,
+            fontSize: `${teamNameFontSize}px`,
+            color: 'rgba(255, 255, 255, 0.9)',
+            transform: placement === 'left' ? '' : 'scaleX(-1)',
+          }}
+        >
+          {teamName ?? ' '}
         </Box>
-        <Box sx={{
-          height: `${scoreBlockHeight}px`,
-          fontSize: '100px',
-          flexDirection: placement === "left" ? 'row' : 'row-reverse',
-          display: 'flex',
-          transform: placement === "left" ? '' : 'scaleX(-1)',
-        }}>
+        <Box
+          sx={{
+            height: `${scoreBlockHeight}px`,
+            fontSize: '100px',
+            flexDirection: placement === 'left' ? 'row' : 'row-reverse',
+            display: 'flex',
+            transform: placement === 'left' ? '' : 'scaleX(-1)',
+          }}
+        >
           {/* 点数表示 */}
-          <CenterFlex sx={{
-            width: '280px',
-           }}>
+          <CenterFlex
+            sx={{
+              width: '280px',
+            }}
+          >
             {displayScore.scoreState.vgoal ? (
-              <Box sx={{ fontSize: "48px", pb: 3 }}>
-                <Box>
-                  {config.rule.vgoal.name}
-                </Box>
-                <CenterFlex sx={{ fontSize: "32px", flexDirection: "row", color: "rgba(30, 30, 30, 0.9)" }}>
+              <Box sx={{ fontSize: '48px', pb: 3 }}>
+                <Box>{config.rule.vgoal.name}</Box>
+                <CenterFlex
+                  sx={{
+                    fontSize: '32px',
+                    flexDirection: 'row',
+                    color: 'rgba(30, 30, 30, 0.9)',
+                  }}
+                >
                   {displayScore.value}
                   &nbsp;/&nbsp;
-                  <TimerIcon sx={{ mr: 1 }} />{formatTime(displayScore.scoreState.vgoal, "m:ss")}
+                  <TimerIcon sx={{ mr: 1 }} />
+                  {formatTime(displayScore.scoreState.vgoal, 'm:ss')}
                 </CenterFlex>
               </Box>
             ) : (
-              <CenterFlex sx={{ fontSize: '90px', lineHeight: `${scoreBlockHeight}px` }}>
+              <CenterFlex
+                sx={{ fontSize: '90px', lineHeight: `${scoreBlockHeight}px` }}
+              >
                 {displayScore.value}
               </CenterFlex>
             )}
           </CenterFlex>
           {/* 詳細表示 */}
-          <Box sx={{
-            width: '300px',
-            height: '135px',
-            padding: placement === "left" ? '0 0 0 20px' : '0 20px 0 0',
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'center',
-            fontSize: '24px',
-            color: 'rgba(30, 30, 30, 0.9)',
-          }}>
-            <ScoreSubDisplay
-              fieldSide={fieldSide}
-              placement={placement}
-            />
+          <Box
+            sx={{
+              width: '300px',
+              height: '135px',
+              padding: placement === 'left' ? '0 0 0 20px' : '0 20px 0 0',
+              display: 'flex',
+              flexDirection: 'row',
+              justifyContent: 'center',
+              fontSize: '24px',
+              color: 'rgba(30, 30, 30, 0.9)',
+            }}
+          >
+            <ScoreSubDisplay fieldSide={fieldSide} placement={placement} />
           </Box>
         </Box>
       </Box>
-      <Box sx={{
-        display: "flex",
-        justifyContent: placement === "left" ? "flex-start" : "flex-end",
-        position: "relative",
-        width: '420px',
-        top: "-70px",
-        left: placement === "left" ? "180px" : "0",
-        clipPath: placement === "left"
-          ? 'polygon(0 100%, 71% 100%, 100% 0, 29% 0)'
-          : 'polygon(0 0, 29% 100%, 100% 100%, 71% 0)',
-      }}>
-        {displayScore.scoreState.winner &&
-          <CenterFlex sx={{
-            height: "70px",
-            width: '420px',
-            backgroundColor: `${color}`,
-            fontSize: "42px",
-            color: "rgba(255, 255, 255, 0.95)",
-          }}>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: placement === 'left' ? 'flex-start' : 'flex-end',
+          position: 'relative',
+          width: '420px',
+          top: '-70px',
+          left: placement === 'left' ? '180px' : '0',
+          clipPath:
+            placement === 'left'
+              ? 'polygon(0 100%, 71% 100%, 100% 0, 29% 0)'
+              : 'polygon(0 0, 29% 100%, 100% 100%, 71% 0)',
+        }}
+      >
+        {displayScore.scoreState.winner && (
+          <CenterFlex
+            sx={{
+              height: '70px',
+              width: '420px',
+              backgroundColor: `${color}`,
+              fontSize: '42px',
+              color: 'rgba(255, 255, 255, 0.95)',
+            }}
+          >
             Winner
           </CenterFlex>
-        }
+        )}
       </Box>
     </Box>
   );
@@ -123,45 +146,57 @@ export const MainHud = ({
   showScoreBoard,
   params,
 }: {
-  showScoreBoard: boolean,
-  params: { reverse: boolean },
+  showScoreBoard: boolean;
+  params: { reverse: boolean };
 }) => {
   return (
-    <Box sx={{
-      width: '100%',
-      height: '320px',
-      display: 'flex',
-    }}>
-      <SlideTransition in={showScoreBoard} direction="left" duration={800} appear={false}>
+    <Box
+      sx={{
+        width: '100%',
+        height: '320px',
+        display: 'flex',
+      }}
+    >
+      <SlideTransition
+        in={showScoreBoard}
+        direction="left"
+        duration={800}
+        appear={false}
+      >
         <Box>
           <ScoreBlock
-            fieldSide={ params.reverse ? "blue" : "red" }
+            fieldSide={params.reverse ? 'blue' : 'red'}
             placement="left"
           />
         </Box>
       </SlideTransition>
       <TimerDisplay
         sxContainer={{
-          height: "190px",
-          fontSize: "20px",
+          height: '190px',
+          fontSize: '20px',
         }}
         sxDescription={{
-          height: "50px",
-          lineHeight: "50px",
+          height: '50px',
+          lineHeight: '50px',
         }}
         sxTime={{
-          height: "90px",
-          lineHeight: "90px",
+          height: '90px',
+          lineHeight: '90px',
         }}
         sxMatchName={{
-          height: "50px",
-          lineHeight: "50px",
+          height: '50px',
+          lineHeight: '50px',
         }}
       />
-      <SlideTransition in={showScoreBoard} direction="right" duration={800} appear={false}>
+      <SlideTransition
+        in={showScoreBoard}
+        direction="right"
+        duration={800}
+        appear={false}
+      >
         <Box>
           <ScoreBlock
-            fieldSide={ params.reverse ? "red" : "blue" }
+            fieldSide={params.reverse ? 'red' : 'blue'}
             placement="right"
           />
         </Box>

--- a/packages/client/src/components/StreamingOverlay/gameLike/index.tsx
+++ b/packages/client/src/components/StreamingOverlay/gameLike/index.tsx
@@ -1,0 +1,171 @@
+import { useSelector } from 'react-redux';
+import { Box } from '@mui/material';
+import TimerIcon from '@mui/icons-material/Timer';
+import { CenterFlex } from '@/ui/CenterFlex';
+import { SlideTransition } from '@/ui/SlideTransition';
+import { RootState } from '@/slices';
+import { FieldSideType } from '@/slices/score';
+import { useDisplayScore } from '@/functional/useDisplayScore';
+import { formatTime } from '@/util/formatTime';
+import { config } from '@/config/load';
+import { TimerDisplay } from '../TimerDisplay';
+import { ScoreSubDisplay } from './ScoreSubDisplay';
+
+const ScoreBlock = (props: {
+  fieldSide: FieldSideType,
+  placement: "left" | "right",
+}) => {
+  const { fieldSide, placement } = props;
+  const teamName = useSelector<RootState, string | undefined>((state) => state.match.teams[fieldSide]?.shortName);
+  const displayScore = useDisplayScore(fieldSide);
+
+  const color = fieldSide == "blue" ? "rgba(0, 0, 240, 0.8)" : "rgba(240, 0, 0, 0.8)";
+
+  const containerHeight = 260;
+  const nameBlockHeight = 55;
+  const scoreBlockHeight = containerHeight - nameBlockHeight - 5; // 若干調整
+  const teamNameFontSize = 30;
+
+  return (
+    <Box>
+      <Box sx={{
+        width: '600px',
+        height: `${containerHeight}px`,
+        textAlign: 'center',
+        backgroundColor: 'rgba(240, 240, 240, 0.8)',
+        clipPath: 'polygon(0 0, 0 100%, 30% 100%, 50% 190px, 100% 190px, 100% 0)',
+        transform: placement === "left" ? '' : 'scaleX(-1)',
+      }}>
+        <Box sx={{
+          height: `${nameBlockHeight}px`,
+          lineHeight: `${nameBlockHeight + 2}px`, // ちょっと調整
+          backgroundColor: color,
+          fontSize: `${teamNameFontSize}px`,
+          color: "rgba(255, 255, 255, 0.9)",
+          transform: placement === "left" ? '' : 'scaleX(-1)',
+        }}>
+          {teamName ?? " "}
+        </Box>
+        <Box sx={{
+          height: `${scoreBlockHeight}px`,
+          fontSize: '100px',
+          flexDirection: placement === "left" ? 'row' : 'row-reverse',
+          display: 'flex',
+          transform: placement === "left" ? '' : 'scaleX(-1)',
+        }}>
+          {/* 点数表示 */}
+          <CenterFlex sx={{
+            width: '280px',
+           }}>
+            {displayScore.scoreState.vgoal ? (
+              <Box sx={{ fontSize: "48px", pb: 3 }}>
+                <Box>
+                  {config.rule.vgoal.name}
+                </Box>
+                <CenterFlex sx={{ fontSize: "32px", flexDirection: "row", color: "rgba(30, 30, 30, 0.9)" }}>
+                  {displayScore.value}
+                  &nbsp;/&nbsp;
+                  <TimerIcon sx={{ mr: 1 }} />{formatTime(displayScore.scoreState.vgoal, "m:ss")}
+                </CenterFlex>
+              </Box>
+            ) : (
+              <CenterFlex sx={{ fontSize: '90px', lineHeight: `${scoreBlockHeight}px` }}>
+                {displayScore.value}
+              </CenterFlex>
+            )}
+          </CenterFlex>
+          {/* 詳細表示 */}
+          <Box sx={{
+            width: '300px',
+            height: '135px',
+            padding: placement === "left" ? '0 0 0 20px' : '0 20px 0 0',
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'center',
+            fontSize: '24px',
+            color: 'rgba(30, 30, 30, 0.9)',
+          }}>
+            <ScoreSubDisplay
+              fieldSide={fieldSide}
+              placement={placement}
+            />
+          </Box>
+        </Box>
+      </Box>
+      <Box sx={{
+        display: "flex",
+        justifyContent: placement === "left" ? "flex-start" : "flex-end",
+        position: "relative",
+        width: '420px',
+        top: "-70px",
+        left: placement === "left" ? "180px" : "0",
+        clipPath: placement === "left"
+          ? 'polygon(0 100%, 71% 100%, 100% 0, 29% 0)'
+          : 'polygon(0 0, 29% 100%, 100% 100%, 71% 0)',
+      }}>
+        {displayScore.scoreState.winner &&
+          <CenterFlex sx={{
+            height: "70px",
+            width: '420px',
+            backgroundColor: `${color}`,
+            fontSize: "42px",
+            color: "rgba(255, 255, 255, 0.95)",
+          }}>
+            Winner
+          </CenterFlex>
+        }
+      </Box>
+    </Box>
+  );
+};
+
+export const MainHud = ({
+  showScoreBoard,
+  params,
+}: {
+  showScoreBoard: boolean,
+  params: { reverse: boolean },
+}) => {
+  return (
+    <Box sx={{
+      width: '100%',
+      height: '320px',
+      display: 'flex',
+    }}>
+      <SlideTransition in={showScoreBoard} direction="left" duration={800} appear={false}>
+        <Box>
+          <ScoreBlock
+            fieldSide={ params.reverse ? "blue" : "red" }
+            placement="left"
+          />
+        </Box>
+      </SlideTransition>
+      <TimerDisplay
+        sxContainer={{
+          height: "190px",
+          fontSize: "20px",
+        }}
+        sxDescription={{
+          height: "50px",
+          lineHeight: "50px",
+        }}
+        sxTime={{
+          height: "90px",
+          lineHeight: "90px",
+        }}
+        sxMatchName={{
+          height: "50px",
+          lineHeight: "50px",
+        }}
+      />
+      <SlideTransition in={showScoreBoard} direction="right" duration={800} appear={false}>
+        <Box>
+          <ScoreBlock
+            fieldSide={ params.reverse ? "red" : "blue" }
+            placement="right"
+          />
+        </Box>
+      </SlideTransition>
+    </Box>
+  );
+};

--- a/packages/client/src/components/StreamingOverlay/gameLike/index.tsx
+++ b/packages/client/src/components/StreamingOverlay/gameLike/index.tsx
@@ -3,11 +3,11 @@ import { Box } from '@mui/material';
 import TimerIcon from '@mui/icons-material/Timer';
 import { CenterFlex } from '@/ui/CenterFlex';
 import { SlideTransition } from '@/ui/SlideTransition';
-import type { RootState } from '@/slices';
-import type { FieldSideType } from '@/slices/score';
+import type { RootState } from '@rolimoa/common/redux';
+import type { FieldSideType } from '@rolimoa/common/redux';
 import { useDisplayScore } from '@/functional/useDisplayScore';
 import { formatTime } from '@/util/formatTime';
-import { config } from '@/config/load';
+import { config } from '@rolimoa/common/config';
 import { TimerDisplay } from '../TimerDisplay';
 import { ScoreSubDisplay } from './ScoreSubDisplay';
 

--- a/packages/client/src/components/StreamingOverlay/simple/index.tsx
+++ b/packages/client/src/components/StreamingOverlay/simple/index.tsx
@@ -3,11 +3,11 @@ import { Box } from '@mui/material';
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
 import { CenterFlex } from '@/ui/CenterFlex';
 import { SlideTransition } from '@/ui/SlideTransition';
-import type { RootState } from '@/slices';
-import type { FieldSideType } from '@/slices/score';
+import type { RootState } from '@rolimoa/common/redux';
+import type { FieldSideType } from '@rolimoa/common/redux';
 import { useDisplayScore } from '@/functional/useDisplayScore';
 import { formatTime } from '@/util/formatTime';
-import { config } from '@/config/load';
+import { config } from '@rolimoa/common/config';
 import { TimerDisplay } from '../TimerDisplay';
 
 const ScoreBlock = (props: {

--- a/packages/client/src/components/StreamingOverlay/simple/index.tsx
+++ b/packages/client/src/components/StreamingOverlay/simple/index.tsx
@@ -1,0 +1,135 @@
+import { useSelector } from 'react-redux';
+import { Box } from '@mui/material';
+import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
+import { CenterFlex } from '@/ui/CenterFlex';
+import { SlideTransition } from '@/ui/SlideTransition';
+import { RootState } from '@/slices';
+import { FieldSideType } from '@/slices/score';
+import { useDisplayScore } from '@/functional/useDisplayScore';
+import { formatTime } from '@/util/formatTime';
+import { config } from '@/config/load';
+import { TimerDisplay } from '../TimerDisplay';
+
+const ScoreBlock = (props: {
+  fieldSide: FieldSideType,
+  placement: "left" | "right",
+}) => {
+  const { fieldSide, placement } = props;
+  const teamName = useSelector<RootState, string | undefined>((state) => state.match.teams[fieldSide]?.shortName);
+  const displayScore = useDisplayScore(fieldSide);
+
+  const color = fieldSide as string; // "blue" | "red"をそのまま文字列として使う
+
+  const containerHeight = 260;
+  const outlineBorderWidth = 8;
+  const innerBorderWidth = 6;
+  const nameBlockHeight = 80;
+  const scoreBlockHeight = containerHeight - nameBlockHeight - outlineBorderWidth * 2;
+
+  let teamNameFontSize = 40;
+  if (teamName && teamName?.length > 12) {
+    teamNameFontSize = 36;
+  }
+  if (teamName && teamName?.length > 14) {
+    teamNameFontSize = 30;
+  }
+
+  return (
+    <Box>
+      <Box sx={{
+        width: '600px',
+        height: `${containerHeight}px`,
+        textAlign: 'center',
+        border: `${outlineBorderWidth}px solid ${color}`,
+        boxSizing: 'border-box',
+        backgroundColor: 'rgba(240, 240, 240, 0.8)',
+      }}>
+        <CenterFlex sx={{
+          height: `${nameBlockHeight}px`,
+          lineHeight: `${nameBlockHeight}px`,
+          borderBottom: `${innerBorderWidth}px solid ${color}`,
+          boxSizing: 'border-box',
+          fontSize: `${teamNameFontSize}px`,
+        }}>
+          {teamName ?? " "}
+        </CenterFlex>
+        <CenterFlex sx={{
+          height: `${scoreBlockHeight}px`,
+          fontSize: '100px',
+          flexDirection: placement === "left" ? 'row' : 'row-reverse',
+        }}>
+          {displayScore.scoreState.vgoal && (
+            <Box sx={{ fontSize: "40px" }}>
+              <Box>
+                {config.rule.vgoal.name}
+              </Box>
+              <Box sx={{
+                mt: 0.5,
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+              }}>
+                <TimerOutlinedIcon sx={{ mr: 1, pt: 0.5, fontSize: "120%", color: "rgba(80, 80, 80, 0.9)" }} />
+                {formatTime(displayScore.scoreState.vgoal, "m:ss")}
+              </Box>
+            </Box>
+          )}
+          <Box sx={{ padding: "0 .5em", lineHeight: `${scoreBlockHeight}px`, }}>
+            {displayScore.value}
+          </Box>
+        </CenterFlex>
+      </Box>
+      <Box sx={{
+        display: "flex",
+        width: "100%",
+        justifyContent: placement === "left" ? "flex-start" : "flex-end",
+      }}>
+        {displayScore.scoreState.winner &&
+          <CenterFlex sx={{
+            width: '240px',
+            height: '60px',
+            backgroundColor: `${color}`,
+            fontSize: "42px",
+            color: "rgba(255, 255, 255, 0.95)",
+          }}>
+            Winner
+          </CenterFlex>
+        }
+      </Box>
+    </Box>
+  );
+};
+
+export const MainHud = ({
+  showScoreBoard,
+  params,
+}: {
+  showScoreBoard: boolean,
+  params: { reverse: boolean },
+}) => {
+  return (
+    <Box sx={{
+      width: '100%',
+      height: '320px',
+      display: 'flex',
+    }}>
+      <SlideTransition in={showScoreBoard} direction="left" duration={800} appear={false}>
+        <Box>
+          <ScoreBlock
+            fieldSide={ params.reverse ? "blue" : "red" }
+            placement="left"
+          />
+        </Box>
+      </SlideTransition>
+      <TimerDisplay />
+      <SlideTransition in={showScoreBoard} direction="right" duration={800} appear={false}>
+        <Box>
+          <ScoreBlock
+            fieldSide={ params.reverse ? "red" : "blue" }
+            placement="right"
+          />
+        </Box>
+      </SlideTransition>
+    </Box>
+  );
+}

--- a/packages/client/src/components/StreamingOverlay/simple/index.tsx
+++ b/packages/client/src/components/StreamingOverlay/simple/index.tsx
@@ -3,19 +3,21 @@ import { Box } from '@mui/material';
 import TimerOutlinedIcon from '@mui/icons-material/TimerOutlined';
 import { CenterFlex } from '@/ui/CenterFlex';
 import { SlideTransition } from '@/ui/SlideTransition';
-import { RootState } from '@/slices';
-import { FieldSideType } from '@/slices/score';
+import type { RootState } from '@/slices';
+import type { FieldSideType } from '@/slices/score';
 import { useDisplayScore } from '@/functional/useDisplayScore';
 import { formatTime } from '@/util/formatTime';
 import { config } from '@/config/load';
 import { TimerDisplay } from '../TimerDisplay';
 
 const ScoreBlock = (props: {
-  fieldSide: FieldSideType,
-  placement: "left" | "right",
+  fieldSide: FieldSideType;
+  placement: 'left' | 'right';
 }) => {
   const { fieldSide, placement } = props;
-  const teamName = useSelector<RootState, string | undefined>((state) => state.match.teams[fieldSide]?.shortName);
+  const teamName = useSelector<RootState, string | undefined>(
+    (state) => state.match.teams[fieldSide]?.shortName,
+  );
   const displayScore = useDisplayScore(fieldSide);
 
   const color = fieldSide as string; // "blue" | "red"をそのまま文字列として使う
@@ -24,7 +26,8 @@ const ScoreBlock = (props: {
   const outlineBorderWidth = 8;
   const innerBorderWidth = 6;
   const nameBlockHeight = 80;
-  const scoreBlockHeight = containerHeight - nameBlockHeight - outlineBorderWidth * 2;
+  const scoreBlockHeight =
+    containerHeight - nameBlockHeight - outlineBorderWidth * 2;
 
   let teamNameFontSize = 40;
   if (teamName && teamName?.length > 12) {
@@ -36,65 +39,82 @@ const ScoreBlock = (props: {
 
   return (
     <Box>
-      <Box sx={{
-        width: '600px',
-        height: `${containerHeight}px`,
-        textAlign: 'center',
-        border: `${outlineBorderWidth}px solid ${color}`,
-        boxSizing: 'border-box',
-        backgroundColor: 'rgba(240, 240, 240, 0.8)',
-      }}>
-        <CenterFlex sx={{
-          height: `${nameBlockHeight}px`,
-          lineHeight: `${nameBlockHeight}px`,
-          borderBottom: `${innerBorderWidth}px solid ${color}`,
+      <Box
+        sx={{
+          width: '600px',
+          height: `${containerHeight}px`,
+          textAlign: 'center',
+          border: `${outlineBorderWidth}px solid ${color}`,
           boxSizing: 'border-box',
-          fontSize: `${teamNameFontSize}px`,
-        }}>
-          {teamName ?? " "}
+          backgroundColor: 'rgba(240, 240, 240, 0.8)',
+        }}
+      >
+        <CenterFlex
+          sx={{
+            height: `${nameBlockHeight}px`,
+            lineHeight: `${nameBlockHeight}px`,
+            borderBottom: `${innerBorderWidth}px solid ${color}`,
+            boxSizing: 'border-box',
+            fontSize: `${teamNameFontSize}px`,
+          }}
+        >
+          {teamName ?? ' '}
         </CenterFlex>
-        <CenterFlex sx={{
-          height: `${scoreBlockHeight}px`,
-          fontSize: '100px',
-          flexDirection: placement === "left" ? 'row' : 'row-reverse',
-        }}>
+        <CenterFlex
+          sx={{
+            height: `${scoreBlockHeight}px`,
+            fontSize: '100px',
+            flexDirection: placement === 'left' ? 'row' : 'row-reverse',
+          }}
+        >
           {displayScore.scoreState.vgoal && (
-            <Box sx={{ fontSize: "40px" }}>
-              <Box>
-                {config.rule.vgoal.name}
-              </Box>
-              <Box sx={{
-                mt: 0.5,
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-              }}>
-                <TimerOutlinedIcon sx={{ mr: 1, pt: 0.5, fontSize: "120%", color: "rgba(80, 80, 80, 0.9)" }} />
-                {formatTime(displayScore.scoreState.vgoal, "m:ss")}
+            <Box sx={{ fontSize: '40px' }}>
+              <Box>{config.rule.vgoal.name}</Box>
+              <Box
+                sx={{
+                  mt: 0.5,
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                }}
+              >
+                <TimerOutlinedIcon
+                  sx={{
+                    mr: 1,
+                    pt: 0.5,
+                    fontSize: '120%',
+                    color: 'rgba(80, 80, 80, 0.9)',
+                  }}
+                />
+                {formatTime(displayScore.scoreState.vgoal, 'm:ss')}
               </Box>
             </Box>
           )}
-          <Box sx={{ padding: "0 .5em", lineHeight: `${scoreBlockHeight}px`, }}>
+          <Box sx={{ padding: '0 .5em', lineHeight: `${scoreBlockHeight}px` }}>
             {displayScore.value}
           </Box>
         </CenterFlex>
       </Box>
-      <Box sx={{
-        display: "flex",
-        width: "100%",
-        justifyContent: placement === "left" ? "flex-start" : "flex-end",
-      }}>
-        {displayScore.scoreState.winner &&
-          <CenterFlex sx={{
-            width: '240px',
-            height: '60px',
-            backgroundColor: `${color}`,
-            fontSize: "42px",
-            color: "rgba(255, 255, 255, 0.95)",
-          }}>
+      <Box
+        sx={{
+          display: 'flex',
+          width: '100%',
+          justifyContent: placement === 'left' ? 'flex-start' : 'flex-end',
+        }}
+      >
+        {displayScore.scoreState.winner && (
+          <CenterFlex
+            sx={{
+              width: '240px',
+              height: '60px',
+              backgroundColor: `${color}`,
+              fontSize: '42px',
+              color: 'rgba(255, 255, 255, 0.95)',
+            }}
+          >
             Winner
           </CenterFlex>
-        }
+        )}
       </Box>
     </Box>
   );
@@ -104,32 +124,44 @@ export const MainHud = ({
   showScoreBoard,
   params,
 }: {
-  showScoreBoard: boolean,
-  params: { reverse: boolean },
+  showScoreBoard: boolean;
+  params: { reverse: boolean };
 }) => {
   return (
-    <Box sx={{
-      width: '100%',
-      height: '320px',
-      display: 'flex',
-    }}>
-      <SlideTransition in={showScoreBoard} direction="left" duration={800} appear={false}>
+    <Box
+      sx={{
+        width: '100%',
+        height: '320px',
+        display: 'flex',
+      }}
+    >
+      <SlideTransition
+        in={showScoreBoard}
+        direction="left"
+        duration={800}
+        appear={false}
+      >
         <Box>
           <ScoreBlock
-            fieldSide={ params.reverse ? "blue" : "red" }
+            fieldSide={params.reverse ? 'blue' : 'red'}
             placement="left"
           />
         </Box>
       </SlideTransition>
       <TimerDisplay />
-      <SlideTransition in={showScoreBoard} direction="right" duration={800} appear={false}>
+      <SlideTransition
+        in={showScoreBoard}
+        direction="right"
+        duration={800}
+        appear={false}
+      >
         <Box>
           <ScoreBlock
-            fieldSide={ params.reverse ? "red" : "blue" }
+            fieldSide={params.reverse ? 'red' : 'blue'}
             placement="right"
           />
         </Box>
       </SlideTransition>
     </Box>
   );
-}
+};

--- a/packages/client/src/pages/ScreenPage.tsx
+++ b/packages/client/src/pages/ScreenPage.tsx
@@ -1,80 +1,73 @@
-import { type FC, useState } from 'react';
-import { ScoreBlock, type ScoreBlockProps } from '@/components/ScoreBlock';
-import { TimerDisplay } from '@/components/TimerDisplay';
-import { usePlaySoundEffect } from '@/functional/usePlaySoundEffect';
-import { Box, Grid2, IconButton } from '@mui/material';
+import { FC, useState } from 'react';
+import { Box, IconButton } from '@mui/material';
 import { CenterFlex } from '@/ui/CenterFlex';
 import CachedIcon from '@mui/icons-material/Cached';
+import { usePlaySoundEffect } from '@/functional/usePlaySoundEffect';
+import { ScoreBoard } from '@/components/Screen/ScoreBoard';
+import { TimerDisplay } from '@/components/Screen/TimerDisplay';
+import { Underlay } from '@/components/Screen/Underlay';
 
 export const ScreenPage: FC = () => {
   usePlaySoundEffect();
 
   const [reverse, setReverse] = useState(false);
-  const onReverseClick = () => {
-    setReverse((toggle) => !toggle);
-  };
-
-  const scoreBlockProps: Partial<ScoreBlockProps> = {
-    rootSx: {
-      borderWidth: '3px',
-    },
-    scoreVariant: 'h1',
-    teamNameVariant: 'h4',
-  };
+  const onReverseClick = () => { setReverse(toggle => !toggle) };
 
   return (
-    <Box sx={{ padding: '2em' }}>
-      <Grid2 container spacing={6}>
-        {/* スコア */}
-        <Grid2
-          size={12}
-          container
-          sx={{
-            justify: 'space-between',
-            alignItems: 'center',
-            flexDirection: reverse ? 'row-reverse' : 'row',
-          }}
-        >
-          <Grid2 size={5}>
-            <ScoreBlock fieldSide="blue" {...scoreBlockProps} />
-          </Grid2>
-          <Grid2 size={2}>
-            <CenterFlex
-              sx={{
-                opacity: 0.1,
-                transition: 'opacity',
-                '&:hover': {
-                  opacity: 1.0,
-                },
-              }}
-            >
-              <IconButton
-                aria-label="delete"
-                color="default"
-                onClick={onReverseClick}
-              >
+    <Box sx={{
+      height: '99vh',
+      overflow: 'hidden',
+    }}>
+      <Box sx={{
+        fontSize: '50px',
+        height: '100vh',
+        p: 0.5,
+        position: 'relative',
+        overflow: 'hidden',
+      }}>
+        <Box>
+          {/* スコア */}
+          <Box sx={{ display: "flex" }}>
+            <Box sx={{ flex: 1 }}>
+              <ScoreBoard fieldSide={ reverse ? "blue" : "red" } placement="left" />
+            </Box>
+            <CenterFlex sx={{
+              opacity: 0.3,
+              transition: "opacity",
+              "&:hover": {
+                opacity: 1.0,
+              },
+              width: "80px",
+              fontSize: "20px",
+            }}>
+              <IconButton color="default" onClick={onReverseClick}>
                 <CachedIcon />
               </IconButton>
             </CenterFlex>
-          </Grid2>
-          <Grid2 size={5}>
-            <ScoreBlock fieldSide="red" {...scoreBlockProps} />
-          </Grid2>
-        </Grid2>
-        {/* タイム */}
-        <Grid2 size={12}>
-          <TimerDisplay
-            descriptionSx={{
-              marginTop: '.5em',
-              marginBottom: '.5em',
-              fontSize: '400%',
-            }}
-            displayTimeSx={{
-              fontSize: '1200%',
-            }}
-          />
-        </Grid2>
-      </Grid2>
+            <Box sx={{ flex: 1 }}>
+              <ScoreBoard fieldSide={ reverse ? "red" : "blue" } placement="right" />
+            </Box>
+          </Box>
+          {/* タイム */}
+          <CenterFlex sx={{
+            py: "0.5em",
+          }}>
+            <TimerDisplay />
+          </CenterFlex>
+        </Box>
+
+        {/* underlay */}
+        <Box sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          height: '100%',
+          width: '100%',
+          zIndex: -100,
+        }}>
+          <Underlay />
+        </Box>
+      </Box>
     </Box>
   );
-};
+}

--- a/packages/client/src/pages/ScreenPage.tsx
+++ b/packages/client/src/pages/ScreenPage.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { useState } from 'react';
 import { Box, IconButton } from '@mui/material';
 import { CenterFlex } from '@/ui/CenterFlex';
 import CachedIcon from '@mui/icons-material/Cached';
@@ -7,67 +7,85 @@ import { ScoreBoard } from '@/components/Screen/ScoreBoard';
 import { TimerDisplay } from '@/components/Screen/TimerDisplay';
 import { Underlay } from '@/components/Screen/Underlay';
 
-export const ScreenPage: FC = () => {
+export const ScreenPage = () => {
   usePlaySoundEffect();
 
   const [reverse, setReverse] = useState(false);
-  const onReverseClick = () => { setReverse(toggle => !toggle) };
+  const onReverseClick = () => {
+    setReverse((toggle) => !toggle);
+  };
 
   return (
-    <Box sx={{
-      height: '99vh',
-      overflow: 'hidden',
-    }}>
-      <Box sx={{
-        fontSize: '50px',
-        height: '100vh',
-        p: 0.5,
-        position: 'relative',
+    <Box
+      sx={{
+        height: '99vh',
         overflow: 'hidden',
-      }}>
+      }}
+    >
+      <Box
+        sx={{
+          fontSize: '50px',
+          height: '100vh',
+          p: 0.5,
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
         <Box>
           {/* スコア */}
-          <Box sx={{ display: "flex" }}>
+          <Box sx={{ display: 'flex' }}>
             <Box sx={{ flex: 1 }}>
-              <ScoreBoard fieldSide={ reverse ? "blue" : "red" } placement="left" />
+              <ScoreBoard
+                fieldSide={reverse ? 'blue' : 'red'}
+                placement="left"
+              />
             </Box>
-            <CenterFlex sx={{
-              opacity: 0.3,
-              transition: "opacity",
-              "&:hover": {
-                opacity: 1.0,
-              },
-              width: "80px",
-              fontSize: "20px",
-            }}>
+            <CenterFlex
+              sx={{
+                opacity: 0.3,
+                transition: 'opacity',
+                '&:hover': {
+                  opacity: 1.0,
+                },
+                width: '80px',
+                fontSize: '20px',
+              }}
+            >
               <IconButton color="default" onClick={onReverseClick}>
                 <CachedIcon />
               </IconButton>
             </CenterFlex>
             <Box sx={{ flex: 1 }}>
-              <ScoreBoard fieldSide={ reverse ? "red" : "blue" } placement="right" />
+              <ScoreBoard
+                fieldSide={reverse ? 'red' : 'blue'}
+                placement="right"
+              />
             </Box>
           </Box>
           {/* タイム */}
-          <CenterFlex sx={{
-            py: "0.5em",
-          }}>
+          <CenterFlex
+            sx={{
+              py: '0.5em',
+            }}
+          >
             <TimerDisplay />
           </CenterFlex>
         </Box>
 
         {/* underlay */}
-        <Box sx={{
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          height: '100%',
-          width: '100%',
-          zIndex: -100,
-        }}>
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            height: '100%',
+            width: '100%',
+            zIndex: -100,
+          }}
+        >
           <Underlay />
         </Box>
       </Box>
     </Box>
   );
-}
+};

--- a/packages/client/src/pages/StreamingOverlayPage.tsx
+++ b/packages/client/src/pages/StreamingOverlayPage.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import type { RootState } from '@/slices';
+import type { RootState } from '@rolimoa/common/redux';
 import { Box, Slide } from '@mui/material';
 import { useSearchParams } from 'react-router-dom';
 import { MainHud } from '@/components/StreamingOverlay/simple';

--- a/packages/client/src/pages/StreamingOverlayPage.tsx
+++ b/packages/client/src/pages/StreamingOverlayPage.tsx
@@ -1,178 +1,14 @@
-import type { FC, Ref } from 'react';
 import { useSelector } from 'react-redux';
-import type { RootState } from '@rolimoa/common/redux';
-import type { FieldSideType } from '@rolimoa/common/redux';
-import { Box, Divider, Slide } from '@mui/material';
-import { useDisplayScore } from '@/functional/useDisplayScore';
-import { useDisplayTimer } from '@/functional/useDisplayTimer';
+import { RootState } from '@/slices';
+import { Box, Slide } from '@mui/material';
 import { useSearchParams } from 'react-router-dom';
-import { CenterFlex } from '@/ui/CenterFlex';
-import { formatTime } from '@/util/formatTime';
-import { config } from '@rolimoa/common/config';
-import { SlideTransition } from '@/ui/SlideTransition';
+import { MainHud } from '@/components/StreamingOverlay/simple';
 
-type ScoreBlockProps = {
-  fieldSide: FieldSideType;
-  placement: 'left' | 'right';
-};
-
-const ScoreBlock: FC<ScoreBlockProps> = ({ fieldSide, placement }) => {
-  const teamName = useSelector<RootState, string | undefined>(
-    (state) => state.match.teams[fieldSide]?.shortName,
-  );
-  const displayScore = useDisplayScore(fieldSide);
-
-  const color = fieldSide as string; // "blue" | "red"をそのまま文字列として使う
-
-  const containerHeight = 260;
-  const outlineBorderWidth = 8;
-  const innerBorderWidth = 6;
-  const nameBlockHeight = 80;
-  const scoreBlockHeight =
-    16 +
-    containerHeight -
-    nameBlockHeight -
-    outlineBorderWidth * 2 -
-    innerBorderWidth; // 文字を下に下げるため微調整
-
-  let teamNameFontSize = 40;
-  if (teamName && teamName?.length > 12) {
-    teamNameFontSize = 36;
-  }
-  if (teamName && teamName?.length > 14) {
-    teamNameFontSize = 30;
-  }
-
-  return (
-    <Box>
-      <Box
-        sx={{
-          width: '600px',
-          height: `${containerHeight}px`,
-          textAlign: 'center',
-          border: `${outlineBorderWidth}px solid ${color}`,
-          boxSizing: 'border-box',
-          backgroundColor: 'rgba(240, 240, 240, 0.8)',
-        }}
-      >
-        <CenterFlex
-          sx={{
-            height: `${nameBlockHeight}px`,
-            lineHeight: `${nameBlockHeight}px`,
-            borderBottom: `${innerBorderWidth}px solid ${color}`,
-            fontSize: `${teamNameFontSize}px`,
-          }}
-        >
-          {teamName ?? ' '}
-        </CenterFlex>
-        <CenterFlex
-          sx={{
-            height: `${scoreBlockHeight}px`,
-            fontSize: '100px',
-            flexDirection: placement === 'left' ? 'row' : 'row-reverse',
-          }}
-        >
-          {displayScore.scoreState.vgoal && (
-            <Box sx={{ fontSize: '40px' }}>
-              <Box>{config.rule.vgoal.name}</Box>
-              <Box>🏴 {formatTime(displayScore.scoreState.vgoal, 'm:ss')}</Box>
-            </Box>
-          )}
-          <Box sx={{ padding: '0 .5em', lineHeight: `${scoreBlockHeight}px` }}>
-            {displayScore.value}
-          </Box>
-        </CenterFlex>
-      </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          width: '100%',
-          justifyContent: placement === 'left' ? 'flex-start' : 'flex-end',
-        }}
-      >
-        {displayScore.scoreState.winner && (
-          <CenterFlex
-            sx={{
-              width: '240px',
-              height: '60px',
-              backgroundColor: `${color}`,
-              fontSize: '42px',
-              color: 'rgba(255, 255, 255, 0.95)',
-            }}
-          >
-            Winner
-          </CenterFlex>
-        )}
-      </Box>
-    </Box>
-  );
-};
-
-const TimerDisplay: FC<{ ref?: Ref<null> }> = ({ ref }) => {
-  const { description, displayTime } = useDisplayTimer();
-  const matchName = useSelector<RootState, string>((state) => state.match.name);
-
-  return (
-    <>
-      <Box
-        ref={ref}
-        sx={{
-          width: '400px',
-          height: '260px',
-          textAlign: 'center',
-          backgroundColor: 'rgba(10, 10, 10, 0.9)',
-          boxSizing: 'border-box',
-          color: 'rgba(240, 240, 240, 0.95)',
-          zIndex: 10,
-        }}
-      >
-        <Box
-          sx={{
-            height: '70px',
-            lineHeight: '70px',
-            fontSize: '24px',
-            display: 'flex',
-            justifyContent: 'center',
-          }}
-        >
-          {description}
-        </Box>
-        <Box
-          sx={{
-            fontFamily: 'DSEG14-Classic',
-            fontWeight: 500,
-            height: '120px',
-            lineHeight: '120px',
-            fontSize: '72px',
-          }}
-        >
-          {displayTime}
-        </Box>
-        <Divider
-          sx={{
-            margin: '0 30px',
-            borderColor: 'rgba(240, 240, 240, 0.5)',
-          }}
-        />
-        <Box
-          sx={{
-            height: '69px',
-            lineHeight: '69px',
-            fontSize: '24px',
-          }}
-        >
-          {matchName ?? ''}
-        </Box>
-      </Box>
-    </>
-  );
-};
-
-export type StreamingOverlayPageParams = {
+type StreamingOverlayPageParams = {
   reverse: boolean;
 };
 
-export const StreamingOverlayPage: FC = () => {
+export const StreamingOverlayPage = () => {
   const [searchParams] = useSearchParams();
   const params: StreamingOverlayPageParams = {
     reverse: searchParams.get('reverse') !== null,
@@ -184,6 +20,7 @@ export const StreamingOverlayPage: FC = () => {
   const showScoreBoard = useSelector<RootState, boolean>(
     (state) => state.streamingInterface.showScoreBoard,
   );
+  const showSubHud = false;
 
   return (
     <Box
@@ -197,42 +34,20 @@ export const StreamingOverlayPage: FC = () => {
       }}
     >
       <Slide in={showMainHud} direction="down" timeout={1000} appear={false}>
-        <Box
-          sx={{
-            width: '100%',
-            height: '320px',
-            display: 'flex',
-          }}
-        >
-          <SlideTransition
-            in={showScoreBoard}
-            direction="left"
-            duration={800}
-            appear={false}
-          >
-            <Box>
-              <ScoreBlock
-                fieldSide={params.reverse ? 'blue' : 'red'}
-                placement="left"
-              />
-            </Box>
-          </SlideTransition>
-          <TimerDisplay />
-          <SlideTransition
-            in={showScoreBoard}
-            direction="right"
-            duration={800}
-            appear={false}
-          >
-            <Box>
-              <ScoreBlock
-                fieldSide={params.reverse ? 'red' : 'blue'}
-                placement="right"
-              />
-            </Box>
-          </SlideTransition>
-        </Box>
+        <MainHud showScoreBoard={showScoreBoard} params={params} />
       </Slide>
+      <Box
+        sx={{
+          width: '100%',
+          position: 'absolute',
+          display: 'flex',
+          justifyContent: 'flex-end',
+        }}
+      >
+        <Slide in={showSubHud} direction="left" timeout={800} appear={false}>
+          <Box sx={{ width: '160px' }}>{/* <SubHudDisplay /> */}</Box>
+        </Slide>
+      </Box>
     </Box>
   );
 };

--- a/packages/client/src/pages/StreamingOverlayPage.tsx
+++ b/packages/client/src/pages/StreamingOverlayPage.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import { RootState } from '@/slices';
+import type { RootState } from '@/slices';
 import { Box, Slide } from '@mui/material';
 import { useSearchParams } from 'react-router-dom';
 import { MainHud } from '@/components/StreamingOverlay/simple';


### PR DESCRIPTION
今まで大会ごとに既存実装を無理矢理書き換えてカスタマイズすることが多かったので、画面のコンポーネントに分割して整理します。

- ひとまず、カスタマイズする部分とそんなに変えない部分を分けた
- スクリーン画面の得点表示を変更
- スクリーン画面と配信オーバーレイページ画面のフォントもNoto San JPに