### PR TITLE
開発環境やDockerfileなどの環境整備

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 .git
 **/node_modules
 **/dist
+**/.vscode
+extension-py/**/.venv
+extension-py/**/__pycache__
+extension-py/**/env.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,36 @@
-FROM node:22-bookworm-slim AS dev
+FROM node:22-bookworm-slim AS base
 WORKDIR /rolimoa
 
-COPY . .
+COPY package*.json ./
+COPY packages/common/package*.json ./packages/common/
+COPY packages/client/package*.json ./packages/client/
+COPY packages/server/package*.json ./packages/server/
+
+
+# 開発環境ステージ
+FROM base AS dev
+
 RUN --mount=type=cache,target=/root/.npm npm ci
+
 
 # ビルドステージ
 FROM dev AS build
 
+COPY . .
 RUN npm run build
 
 
 # 実行環境ステージ
-FROM node:22-bookworm-slim AS prod
-WORKDIR /rolimoa
+FROM base AS prod
 
 ENV NODE_ENV=production
 ENV PORT=8000
 
-COPY --from=build --chown=node:node /rolimoa/ .
-RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
+COPY --from=build /rolimoa/packages/common/dist ./packages/common/dist
+COPY --from=build /rolimoa/packages/client/dist ./packages/client/dist
+COPY --from=build /rolimoa/packages/server/dist ./packages/server/dist
+RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev --workspace=@rolimoa/server \
+    && chown -R node:node .
 
 USER node
 EXPOSE ${PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22-bookworm-slim AS dev
 WORKDIR /rolimoa
 
 COPY . .
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # ビルドステージ
 FROM dev AS build
@@ -15,7 +15,7 @@ FROM node:22-bookworm-slim AS prod
 WORKDIR /rolimoa
 
 COPY --from=build --chown=node:node /rolimoa/ .
-RUN npm ci --omit=dev
+RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
 
 USER node
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,16 @@ RUN npm run build
 FROM node:22-bookworm-slim AS prod
 WORKDIR /rolimoa
 
+ENV NODE_ENV=production
+ENV PORT=8000
+
 COPY --from=build --chown=node:node /rolimoa/ .
 RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
 
 USER node
+EXPOSE ${PORT}
 CMD ["npm", "start"]
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "node", "-e", \
+    "fetch(`http://localhost:${process.env.PORT || '8000'}`).then((res) => res.ok || Promise.reject()).catch(() => { process.exit(1); })" \
+]

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,0 +1,53 @@
+name: rolimoa-prod
+
+services:
+  app:
+    build:
+      context: .
+      target: prod
+    environment:
+      - NODE_ENV=production
+      - PORT=8000
+    ports:
+      - "8000:8000"
+    volumes:
+      - type: volume
+        source: node_modules
+        target: /rolimoa/node_modules
+      - type: volume
+        source: common_node_modules
+        target: /rolimoa/packages/common/node_modules
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  extension-example:
+    image: ghcr.io/astral-sh/uv:debian-slim
+    command: "uv run ./src/examples/basic/main.py"
+    environment:
+      - RoLIMOA_WS_URL=ws://app:8000/ws
+    working_dir: /rolimoa/extension-py
+    volumes:
+      - type: bind
+        source: ./extension-py
+        target: /rolimoa/extension-py
+      - type: volume
+        source: ext_py_venv
+        target: /rolimoa/extension-py/.venv
+    networks:
+      - app-network
+    depends_on:
+      app:
+        condition: service_healthy
+    restart: unless-stopped
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  node_modules:
+  common_node_modules:
+  client_node_modules:
+  server_node_modules:
+  ext_py_venv:

--- a/compose.yml
+++ b/compose.yml
@@ -22,6 +22,8 @@ services:
       context: .
       target: dev
     command: npm run dev:client -- --host
+    environment:
+      - VITE_PROXY_HOST=server:8000
     ports:
       - "5173:5173"
     volumes:

--- a/extension-py/src/examples/basic/main.py
+++ b/extension-py/src/examples/basic/main.py
@@ -7,6 +7,7 @@ RoLIMOAExtensionのかんたんなサンプルコードです
 """
 
 from logging import getLogger, StreamHandler, DEBUG
+import os
 import asyncio
 from rolimoa_extension import RoLIMOAExtension
 
@@ -17,7 +18,8 @@ handler.setLevel(DEBUG)
 logger.setLevel(DEBUG)
 logger.addHandler(handler)
 
-ext = RoLIMOAExtension("ws://localhost:8000/ws", logger=logger)
+url = os.environ.get("RoLIMOA_WS_URL", "ws://localhost:8000/ws")
+ext = RoLIMOAExtension(url, logger=logger)
 
 @ext.on_dispatch("task/setTaskUpdate")
 async def on_task_update_1(payload: dict):

--- a/extension-py/src/rolimoa_extension/rolimoa_extension.py
+++ b/extension-py/src/rolimoa_extension/rolimoa_extension.py
@@ -59,7 +59,11 @@ class RoLIMOAExtension:
                         await self._on_message(message)
 
             except Exception as e:
-                self.logger.error(f"Connection error: {e}")
+                self.logger.error(f"❌接続に失敗しました", {
+                    "url": self.url,
+                    "attempts": attempts,
+                    "error": str(e),
+                })
                 self._callback_invoke(self.on_error_callback, [e])
                 if not isinstance(e, httpx_ws.WebSocketNetworkError):
                     raise e
@@ -121,7 +125,10 @@ class RoLIMOAExtension:
 
 
 async def main():
-    ext = RoLIMOAExtension("ws://localhost:8000/ws")
+    import os
+
+    url = os.environ.get("RoLIMOA_WS_URL", "ws://localhost:8000/ws")
+    ext = RoLIMOAExtension(url)
 
     @ext.on_dispatch("task/setTaskUpdate")
     async def on_task_update(payload: dict):

--- a/packages/client/src/lyricalSocket.ts
+++ b/packages/client/src/lyricalSocket.ts
@@ -15,12 +15,16 @@ export class LyricalSocket {
   private sessionId = '';
 
   private constructor() {
-    this.socket = new ReconnectingWebSocket(
-      `ws://${window.location.hostname}:8000/ws`,
-    );
+    this.socket = new ReconnectingWebSocket(this.url());
     this.socket.onopen = () => {
       console.log(`is connected: ${this.socket.readyState === WebSocket.OPEN}`);
     };
+  }
+
+  private url(): string {
+    const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const host = window.location.host;
+    return `${scheme}://${host}/ws`;
   }
 
   public static isActive(): boolean {

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -8,4 +8,17 @@ export default {
       '@': `${__dirname}/src`,
     },
   },
+  server: {
+    proxy: {
+      '/ws': {
+        target: 'ws://localhost:8000',
+        changeOrigin: true,
+        ws: true,
+      },
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
+  },
 } satisfies UserConfig;

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -1,6 +1,8 @@
 import type { UserConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const PROXY_HOST = process.env.VITE_PROXY_HOST || 'localhost:8000';
+
 export default {
   plugins: [react()],
   resolve: {
@@ -11,12 +13,11 @@ export default {
   server: {
     proxy: {
       '/ws': {
-        target: 'ws://localhost:8000',
-        changeOrigin: true,
+        target: `ws://${PROXY_HOST}`,
         ws: true,
       },
       '/api': {
-        target: 'http://localhost:8000',
+        target: `http://${PROXY_HOST}`,
         changeOrigin: true,
       },
     },

--- a/packages/server/src/backup.ts
+++ b/packages/server/src/backup.ts
@@ -50,8 +50,8 @@ export async function saveToFile(
   }
 }
 
-function createDirectoryIfNotExists(path: string): void {
-  fs.existsSync(path) || fs.mkdirSync(path, { recursive: true });
+function createDirectoryIfNotExists(dirPath: string): void {
+  fs.existsSync(dirPath) || fs.mkdirSync(dirPath, { recursive: true });
 }
 
 function storedObjectValidator(state: RootState): boolean {

--- a/packages/server/src/backup.ts
+++ b/packages/server/src/backup.ts
@@ -8,14 +8,17 @@ import config from '@rolimoa/common/config';
 type StoreType = ReturnType<typeof createStore>;
 
 export function loadFromFile(directoryPath: string): RootState | undefined {
-  const jsonFiles = fs
+  createDirectoryIfNotExists(directoryPath);
+
+  const fileName = fs
     .readdirSync(directoryPath)
-    .filter((name) => name.endsWith('.json'));
-  const fileName = jsonFiles.sort().reverse()[0];
+    .filter((name) => name.endsWith('.json'))
+    .sort()
+    .reverse()[0];
+
   if (!fileName) {
     return undefined;
   }
-
   console.log(`${fileName}が見つかったため、ストアを復元します`);
 
   const filePath = path.join(directoryPath, fileName);
@@ -45,6 +48,10 @@ export async function saveToFile(
   } catch (err) {
     console.error('ストアの保存に失敗しました', err);
   }
+}
+
+function createDirectoryIfNotExists(path: string): void {
+  fs.existsSync(path) || fs.mkdirSync(path, { recursive: true });
 }
 
 function storedObjectValidator(state: RootState): boolean {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -118,5 +118,7 @@ app.get('*', (_req, res, _next) => {
   res.sendFile(path.resolve('../client/dist/index.html'));
 });
 
-app.listen(8000);
+const PORT = Number(process.env.PORT) || 8000;
+
+app.listen(PORT);
 console.log('server start');


### PR DESCRIPTION
## 主な変更点

- Viteの開発サーバー (TCP: 5173) から、WSサーバーへのプロキシを設定
  - クライアントでのポートのハードコードを削除
  - HTTPS の場合、エンドポイントを `wss://examle.com/ws` に
- Webサーバーのポートを8000以外にも対応
  - ひとまず環境変数 `PORT` で指定するように
- Dockerのイメージサイズ削減
- prodステージにはHEALTHCHECKを設定
- compose.prod.ymlを追加（雑に常時起動しておきたいとき便利）