### PR TITLE
Redux sliceのaction変更などいろいろ

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -20,6 +20,7 @@ import { ScreenPage } from '@/pages/ScreenPage';
 import { LoadingOverlay } from '@/ui/LoadingOverlay';
 import { useAppRootTimer } from '@/functional/useAppRootTimer';
 import { useLoadSetting } from '@/functional/useLoadSetting';
+import { ShortcutKeyProvider } from './functional/useShortcutKey';
 import { config } from '@rolimoa/common/config';
 import { LyricalSocket } from './lyricalSocket';
 import { AppMuiThemeProvider } from './AppMuiThemeProvider';
@@ -115,28 +116,33 @@ const App: FC = () => {
   return (
     <>
       <AppMuiThemeProvider>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/referee" element={<RefereePage />} />
-          <Route
-            path="/score/red"
-            element={<ScoreInputPage fieldSide="red" />}
+        <ShortcutKeyProvider>
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/referee" element={<RefereePage />} />
+            <Route
+              path="/score/red"
+              element={<ScoreInputPage fieldSide="red" />}
+            />
+            <Route
+              path="/score/blue"
+              element={<ScoreInputPage fieldSide="blue" />}
+            />
+            <Route path="/admin" element={<AdminPage />} />
+            <Route
+              path="/streaming-overlay-opener"
+              element={<StreamingOverlayOpenerPage />}
+            />
+            <Route
+              path="/streaming-overlay"
+              element={<StreamingOverlayPage />}
+            />
+            <Route path="/screen" element={<ScreenPage />} />
+          </Routes>
+          <LoadingOverlay
+            loading={!config.client.standalone_mode && !isConnect}
           />
-          <Route
-            path="/score/blue"
-            element={<ScoreInputPage fieldSide="blue" />}
-          />
-          <Route path="/admin" element={<AdminPage />} />
-          <Route
-            path="/streaming-overlay-opener"
-            element={<StreamingOverlayOpenerPage />}
-          />
-          <Route path="/streaming-overlay" element={<StreamingOverlayPage />} />
-          <Route path="/screen" element={<ScreenPage />} />
-        </Routes>
-        <LoadingOverlay
-          loading={!config.client.standalone_mode && !isConnect}
-        />
+        </ShortcutKeyProvider>
       </AppMuiThemeProvider>
     </>
   );

--- a/packages/client/src/components/ScoreInput/GlobalObjectContainer.tsx
+++ b/packages/client/src/components/ScoreInput/GlobalObjectContainer.tsx
@@ -34,7 +34,7 @@ export const GlobalObjectContainer: FC<GlobalObjectContainerProps> = ({
 
   const stateUpdate = useCallback(
     (value: number, command = '') => {
-      const taskUpdateAction = scoreStateSlice.actions.setGloablUpdate({
+      const taskUpdateAction = scoreStateSlice.actions.setGlobalUpdate({
         taskObjectId: id,
         afterValue: value,
       });

--- a/packages/client/src/components/ScoreInput/MultiButtonControl.tsx
+++ b/packages/client/src/components/ScoreInput/MultiButtonControl.tsx
@@ -1,10 +1,18 @@
-import { type FC, useCallback } from 'react';
-import { Button, ButtonGroup, Box, Paper, Typography } from '@mui/material';
+import { type FC, useCallback, useRef } from 'react';
+import {
+  Button,
+  ButtonGroup,
+  Box,
+  Paper,
+  Typography,
+  type ButtonProps,
+} from '@mui/material';
 import type { SxProps } from '@mui/material/styles';
 import type {
   TaskObjectConfigType,
   taskObjectMultiButtonUiType,
 } from '@rolimoa/common/config';
+import { useShortcutKey } from '@/functional/useShortcutKey';
 
 interface MultiButtonControlProps {
   color: 'primary' | 'secondary' | 'inherit';
@@ -79,23 +87,42 @@ export const MultiButtonControl: FC<MultiButtonControlProps> = ({
 
       <Box sx={{ pt: 0.5 }}>
         <ButtonGroup sx={buttonGroupSx} color={color}>
-          {controlConfig.option.buttons.map((button) => {
-            const { disabled, onClick } = buttonProps(button.command);
-
-            return (
-              <Button
-                key={button.command}
-                sx={innnerButtonSx}
-                variant={button.style?.variant ?? 'contained'}
-                onClick={onClick}
-                disabled={disabled}
-              >
-                {button.label}
-              </Button>
-            );
-          })}
+          {controlConfig.option.buttons.map((button) => (
+            <GroupedButton
+              key={button.command}
+              shortcutKey={button?.shortcutKey}
+              buttonProps={{
+                ...buttonProps(button.command),
+                sx: innnerButtonSx,
+                variant: button.style?.variant ?? 'contained',
+              }}
+            >
+              {button.label}
+            </GroupedButton>
+          ))}
         </ButtonGroup>
       </Box>
     </Paper>
+  );
+};
+
+const GroupedButton = (props: {
+  children: React.ReactNode;
+  buttonProps: ButtonProps;
+  shortcutKey?: string;
+}) => {
+  const { children, buttonProps, shortcutKey } = props;
+
+  const ref = useRef<HTMLButtonElement>(null);
+  useShortcutKey(shortcutKey, () => {
+    if (ref.current) {
+      ref.current.click();
+    }
+  });
+
+  return (
+    <Button {...buttonProps} ref={ref}>
+      {children}
+    </Button>
   );
 };

--- a/packages/client/src/components/TimerMasterContainer.tsx
+++ b/packages/client/src/components/TimerMasterContainer.tsx
@@ -89,22 +89,10 @@ export const TimerMasterContainer: FC = () => {
     const now = Date.now() + timeOffset;
     if (currentPhase.pausedTime) {
       // 再開
-      LyricalSocket.dispatchAll([
-        phaseStateSlice.actions.setPause({
-          pausedTime: undefined,
-        }),
-        phaseStateSlice.actions.setState({
-          id: currentPhase.id,
-          startTime: now - (currentPhase.pausedTime - currentPhase.startTime),
-        }),
-      ]);
+      LyricalSocket.dispatchAll([phaseStateSlice.actions.doResume({ now })]);
     } else {
       // 一時停止
-      LyricalSocket.dispatchAll([
-        phaseStateSlice.actions.setPause({
-          pausedTime: now,
-        }),
-      ]);
+      LyricalSocket.dispatchAll([phaseStateSlice.actions.doPause({ now })]);
     }
   }, [currentPhase, timeOffset]);
 

--- a/packages/client/src/custom/event.scoreUpdate.ts
+++ b/packages/client/src/custom/event.scoreUpdate.ts
@@ -1,0 +1,51 @@
+import type { Dispatch, UnknownAction } from '@reduxjs/toolkit';
+import type { scoreStateSlice } from '@rolimoa/common/redux';
+
+type ActionType =
+  | ReturnType<typeof scoreStateSlice.actions.setTaskUpdate>
+  | ReturnType<typeof scoreStateSlice.actions.setGloablUpdate>;
+
+export type ScoreUpdateContext = {
+  dispatch: Dispatch<UnknownAction>;
+  event: {
+    type: 'scoreUpdate';
+    afterValue: number;
+    fieldSide: 'blue' | 'red' | 'global';
+    taskObjectId: string;
+    command?: string;
+    action: ActionType;
+  };
+  extra?: {
+    [key: string]: unknown;
+  };
+};
+
+/**
+ * 点数の更新をdispatchする前のイベント
+ *
+ * この関数でfalseを返すと、点数の更新など後続の処理をキャンセルします。
+ * その場合、onScoreUpdateAfterも実行されません。
+ *
+ * @param _ctx
+ */
+export function onScoreUpdateBefore(_ctx: ScoreUpdateContext): boolean {
+  // const { event } = _ctx;
+  // if (event.fieldSide === 'blue' && event.taskObjectId === 'hoge') {
+  //   console.log('青コートだけ11点以上にさせない');
+  //   return event.afterValue <= 10;
+  // }
+
+  return true;
+}
+
+/**
+ * 点数の更新をdispatchした後のイベント
+ *
+ * @param _ctx
+ */
+export function onScoreUpdateAfter(_ctx: ScoreUpdateContext): void {
+  // const { event } = _ctx;
+  // console.log(
+  //   `${event.fieldSide}コートの${event.taskObjectId}が${event.afterValue}に更新されたよ`,
+  // );
+}

--- a/packages/client/src/custom/event.scoreUpdate.ts
+++ b/packages/client/src/custom/event.scoreUpdate.ts
@@ -3,7 +3,7 @@ import type { scoreStateSlice } from '@rolimoa/common/redux';
 
 type ActionType =
   | ReturnType<typeof scoreStateSlice.actions.setTaskUpdate>
-  | ReturnType<typeof scoreStateSlice.actions.setGloablUpdate>;
+  | ReturnType<typeof scoreStateSlice.actions.setGlobalUpdate>;
 
 export type ScoreUpdateContext = {
   dispatch: Dispatch<UnknownAction>;

--- a/packages/client/src/functional/useShortcutKey.tsx
+++ b/packages/client/src/functional/useShortcutKey.tsx
@@ -1,0 +1,119 @@
+import {
+  useEffect,
+  useCallback,
+  createContext,
+  useContext,
+  useState,
+  type ReactNode,
+} from 'react';
+
+// ショートカットキーのコンテキストの型
+interface ShortcutContextType {
+  registerShortcut: (key: string, callback: () => void) => () => void;
+  unregisterShortcut: (key: string) => void;
+}
+
+// デフォルト値を持つコンテキスト
+const ShortcutContext = createContext<ShortcutContextType>({
+  registerShortcut: () => () => {},
+  unregisterShortcut: () => {},
+});
+
+// ショートカットキーのプロバイダーの型
+interface ShortcutKeyProviderProps {
+  children: ReactNode;
+}
+
+// ショートカットキーのプロバイダー
+export const ShortcutKeyProvider = (props: ShortcutKeyProviderProps) => {
+  // 登録されたショートカットを管理するstate
+  const [shortcuts, setShortcuts] = useState<Map<string, () => void>>(
+    new Map(),
+  );
+
+  // ショートカットの登録
+  const registerShortcut = useCallback((key: string, callback: () => void) => {
+    setShortcuts((prev) => {
+      const newMap = new Map(prev);
+      newMap.set(key.toLowerCase(), callback);
+      return newMap;
+    });
+
+    // 登録解除のための関数を返す
+    return () => {
+      setShortcuts((prev) => {
+        const newMap = new Map(prev);
+        newMap.delete(key.toLowerCase());
+        return newMap;
+      });
+    };
+  }, []);
+
+  // ショートカットの登録解除
+  const unregisterShortcut = useCallback((key: string) => {
+    setShortcuts((prev) => {
+      const newMap = new Map(prev);
+      newMap.delete(key.toLowerCase());
+      return newMap;
+    });
+  }, []);
+
+  // キーイベントのハンドラー
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // Ctrlやメタキーと併用されているときは無視（ブラウザショートカットを優先）
+      if (e.ctrlKey || e.metaKey) return;
+
+      // 入力欄でのキー入力は無視
+      if (
+        e.target instanceof HTMLElement &&
+        (e.target.tagName === 'INPUT' ||
+          e.target.tagName === 'TEXTAREA' ||
+          e.target.isContentEditable)
+      ) {
+        return;
+      }
+
+      // 押されたキーを小文字に変換して一致するショートカットを検索
+      const key = e.key.toLowerCase();
+      if (shortcuts.has(key)) {
+        e.preventDefault();
+        shortcuts.get(key)?.();
+      }
+    },
+    [shortcuts],
+  );
+
+  // イベントリスナーの登録と解除
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  return (
+    <ShortcutContext.Provider value={{ registerShortcut, unregisterShortcut }}>
+      {props.children}
+    </ShortcutContext.Provider>
+  );
+};
+
+// カスタムフック: useShortcutKey
+export function useShortcutKey(
+  key: string | undefined,
+  callback: () => void,
+  dependencies: unknown[] = [],
+) {
+  const { registerShortcut } = useContext(ShortcutContext);
+
+  useEffect(() => {
+    if (!key || !callback) return;
+
+    // ショートカットを登録し、解除関数を取得
+    const unregister = registerShortcut(key, callback);
+
+    // クリーンアップ時にショートカットを解除
+    return unregister;
+  }, [key, callback, registerShortcut, ...dependencies]);
+}

--- a/packages/common/src/config/config.ts
+++ b/packages/common/src/config/config.ts
@@ -386,4 +386,7 @@ export default {
   client: {
     standalone_mode: false,
   },
+  option: {
+    truncate_millisec_on_pause: true,
+  },
 } as ConfigType;

--- a/packages/common/src/config/config.ts
+++ b/packages/common/src/config/config.ts
@@ -89,6 +89,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
+                shortcutKey: 'Q'
               },
             ],
           },
@@ -115,6 +116,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
+                shortcutKey: 'W'
               },
               {
                 command: '+2',
@@ -149,6 +151,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
+                shortcutKey: 'A'
               },
               {
                 command: '+2',
@@ -183,6 +186,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
+                shortcutKey: 'S'
               },
               {
                 command: '+2',
@@ -217,6 +221,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
+                shortcutKey: 'Z'
               },
               {
                 command: '+2',
@@ -244,6 +249,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
+                shortcutKey: 'X'
               },
             ],
           },

--- a/packages/common/src/config/config.ts
+++ b/packages/common/src/config/config.ts
@@ -89,7 +89,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
-                shortcutKey: 'Q'
+                shortcutKey: 'Q',
               },
             ],
           },
@@ -116,7 +116,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
-                shortcutKey: 'W'
+                shortcutKey: 'W',
               },
               {
                 command: '+2',
@@ -151,7 +151,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
-                shortcutKey: 'A'
+                shortcutKey: 'A',
               },
               {
                 command: '+2',
@@ -186,7 +186,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
-                shortcutKey: 'S'
+                shortcutKey: 'S',
               },
               {
                 command: '+2',
@@ -221,7 +221,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
-                shortcutKey: 'Z'
+                shortcutKey: 'Z',
               },
               {
                 command: '+2',
@@ -249,7 +249,7 @@ export default {
               {
                 command: '+1',
                 label: '+1',
-                shortcutKey: 'X'
+                shortcutKey: 'X',
               },
             ],
           },

--- a/packages/common/src/config/schema/controlPanel.ts
+++ b/packages/common/src/config/schema/controlPanel.ts
@@ -63,6 +63,7 @@ export const taskObjectMultiButtonSchema = z.object({
             variant: z.enum(['text', 'outlined', 'contained']).optional(),
           })
           .optional(),
+        shortcutKey: z.string().optional(),
       }),
     ),
     vertical: z.boolean().optional(),

--- a/packages/common/src/config/schema/index.ts
+++ b/packages/common/src/config/schema/index.ts
@@ -99,4 +99,7 @@ export const configSchema = z.object({
   client: z.object({
     standalone_mode: z.boolean(),
   }),
+  option: z.object({
+    truncate_millisec_on_pause: z.boolean().optional(),
+  }),
 });

--- a/packages/common/src/redux/slices/phase.ts
+++ b/packages/common/src/redux/slices/phase.ts
@@ -1,4 +1,5 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { config } from '../../config/index.js';
 
 // `startTime`から経過した現在の秒数を取得する
 export function calculateElapsedSecond(
@@ -47,8 +48,38 @@ export const phaseStateSlice = createSlice({
     ) => {
       state.elapsedSecond = action.payload.newElapsedSecond;
     },
-    setPause: (state, action: PayloadAction<{ pausedTime?: number }>) => {
-      state.current.pausedTime = action.payload.pausedTime;
+    // タイマーを一時停止する
+    doPause: (state, action: PayloadAction<{ now: number }>) => {
+      if (state.current.pausedTime) {
+        console.warn('ふぇぇ！一時停止中に再度一時停止しようとしてるよぉ');
+        return;
+      }
+      state.current.pausedTime = action.payload.now;
+    },
+    // タイマーの一時停止を解除する
+    doResume: (state, action: PayloadAction<{ now: number }>) => {
+      if (!state.current.pausedTime) {
+        console.warn('ふぇぇ！一時停止していないのに再開しようとしてるよぉ');
+        return;
+      }
+
+      const now = action.payload.now;
+      if (config.option.truncate_millisec_on_pause) {
+        // 再開時に、ミリ秒を切り捨てる (e.g: 9.9 sで一時停止したときに、9.0 sからタイマーを再開する)
+        const newElapsedSec = calculateElapsedSecond(
+          state.current.startTime,
+          state.current.pausedTime,
+        );
+        const delta = 10; // 多分大丈夫だけど、丸め誤差対策に念のため…
+        state.current.startTime = now - (newElapsedSec * 1000 + delta);
+        state.current.pausedTime = undefined;
+      } else {
+        // 切り捨てない
+        const pausedDuration =
+          state.current.pausedTime - state.current.startTime;
+        state.current.startTime = now - pausedDuration;
+        state.current.pausedTime = undefined;
+      }
     },
   },
 });

--- a/packages/common/src/redux/slices/score.ts
+++ b/packages/common/src/redux/slices/score.ts
@@ -48,7 +48,7 @@ export const scoreInitialState: ScoreState = {
   ),
 };
 
-type GloablUpdateActionPayload = {
+type GloballUpdateActionPayload = {
   taskObjectId: string;
   afterValue: number;
 };
@@ -64,9 +64,9 @@ export const scoreStateSlice = createSlice({
   initialState: scoreInitialState,
   reducers: {
     setState: (_, action: PayloadAction<ScoreState>) => action.payload,
-    setGloablUpdate: (
+    setGlobalUpdate: (
       state,
-      action: PayloadAction<GloablUpdateActionPayload>,
+      action: PayloadAction<GloballUpdateActionPayload>,
     ) => {
       state.global[action.payload.taskObjectId] = action.payload.afterValue;
     },

--- a/packages/common/src/redux/slices/score.ts
+++ b/packages/common/src/redux/slices/score.ts
@@ -48,7 +48,7 @@ export const scoreInitialState: ScoreState = {
   ),
 };
 
-type GloballUpdateActionPayload = {
+type GlobalUpdateActionPayload = {
   taskObjectId: string;
   afterValue: number;
 };
@@ -66,7 +66,7 @@ export const scoreStateSlice = createSlice({
     setState: (_, action: PayloadAction<ScoreState>) => action.payload,
     setGlobalUpdate: (
       state,
-      action: PayloadAction<GloballUpdateActionPayload>,
+      action: PayloadAction<GlobalUpdateActionPayload>,
     ) => {
       state.global[action.payload.taskObjectId] = action.payload.afterValue;
     },


### PR DESCRIPTION
<!-- GitHub Copilot への指示: レビューやコメントは日本語でしてください -->

- Redux sliceのsetPauseを廃止して、doPause/doResumeに変更
- タスクオブジェクトの更新前後で呼び出す custmo/event.scoreUpdate.ts を追加
- 試験的にキーボードによる得点操作の機能を実装